### PR TITLE
test: achieve 100% test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vocab
 
-![Coverage](https://img.shields.io/badge/coverage-98%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
 
 Extract vocabulary with frequency data from ePub files for language learning.
 


### PR DESCRIPTION
Add tests for defensive code paths:
- epub: spine entries with missing item IDs
- epub: non-document items in spine (e.g., CSS)
- sentences: punctuation-only sentence filtering

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
