### PR TITLE
feat(sentences): switch to large spaCy models for better lemmatization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ You'll need to download spaCy language models for the languages you want to proc
 
 ```bash
 # French
-python -m spacy download fr_core_news_sm
+python -m spacy download fr_core_news_lg
 
 # Other languages
-python -m spacy download en_core_web_sm  # English
-python -m spacy download de_core_news_sm  # German
-python -m spacy download es_core_news_sm  # Spanish
+python -m spacy download en_core_web_lg  # English
+python -m spacy download de_core_news_lg  # German
+python -m spacy download es_core_news_lg  # Spanish
 ```
+
+We use the large (`_lg`) models rather than small (`_sm`) models because they produce significantly better lemmatization. In testing with French text, the small model generated truncated lemmas (e.g., "couvertur" instead of "couverture"), spurious verb forms (e.g., "villa" → "viller"), and inconsistent case normalization. The large models produce ~12% fewer unique lemmas through better consolidation, meaning cleaner vocabulary lists with fewer errors to manually correct. The trade-off is larger download size (~500MB vs ~15MB per model).
 
 ## Usage
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -90,7 +90,7 @@ class Vocabulary:
 - spacy
 
 **spaCy models (not pip packages, downloaded separately):**
-- fr_core_news_sm (French, for initial implementation)
+- fr_core_news_lg (French, for initial implementation)
 - Additional models as needed for other languages
 
 ---
@@ -182,7 +182,7 @@ def extract_sentences(text: str, language: str) -> Generator[Sentence, None, Non
 ```
 
 **spaCy model loading:**
-- Map language codes to model names (e.g., "fr" → "fr_core_news_sm")
+- Map language codes to model names (e.g., "fr" → "fr_core_news_lg")
 - Cache loaded models to avoid reloading
 - Raise clear error if model not installed
 

--- a/src/vocab/sentences.py
+++ b/src/vocab/sentences.py
@@ -9,13 +9,13 @@ from vocab.models import Sentence
 
 # Mapping of language codes to spaCy model names
 _LANGUAGE_MODELS: dict[str, str] = {
-    "fr": "fr_core_news_sm",
-    "en": "en_core_web_sm",
-    "de": "de_core_news_sm",
-    "es": "es_core_news_sm",
-    "it": "it_core_news_sm",
-    "pt": "pt_core_news_sm",
-    "nl": "nl_core_news_sm",
+    "fr": "fr_core_news_lg",
+    "en": "en_core_web_lg",
+    "de": "de_core_news_lg",
+    "es": "es_core_news_lg",
+    "it": "it_core_news_lg",
+    "pt": "pt_core_news_lg",
+    "nl": "nl_core_news_lg",
 }
 
 # Cache for loaded spaCy models

--- a/tests/test_sentences.py
+++ b/tests/test_sentences.py
@@ -243,28 +243,28 @@ class TestSpacyModelNotFoundError:
 
     def test_error_message_contains_model_name(self) -> None:
         """Should include model name in error message."""
-        error = SpacyModelNotFoundError("fr", "fr_core_news_sm")
+        error = SpacyModelNotFoundError("fr", "fr_core_news_lg")
 
-        assert "fr_core_news_sm" in str(error)
+        assert "fr_core_news_lg" in str(error)
 
     def test_error_message_contains_language(self) -> None:
         """Should include language code in error message."""
-        error = SpacyModelNotFoundError("fr", "fr_core_news_sm")
+        error = SpacyModelNotFoundError("fr", "fr_core_news_lg")
 
         assert "'fr'" in str(error)
 
     def test_error_message_contains_install_instructions(self) -> None:
         """Should include installation instructions."""
-        error = SpacyModelNotFoundError("fr", "fr_core_news_sm")
+        error = SpacyModelNotFoundError("fr", "fr_core_news_lg")
 
-        assert "python -m spacy download fr_core_news_sm" in str(error)
+        assert "python -m spacy download fr_core_news_lg" in str(error)
 
     def test_stores_language_and_model(self) -> None:
         """Should store language and model_name as attributes."""
-        error = SpacyModelNotFoundError("fr", "fr_core_news_sm")
+        error = SpacyModelNotFoundError("fr", "fr_core_news_lg")
 
         assert error.language == "fr"
-        assert error.model_name == "fr_core_news_sm"
+        assert error.model_name == "fr_core_news_lg"
 
 
 class TestLongText:


### PR DESCRIPTION
Testing with French text showed that small models produce lower quality
lemmas: truncated forms (e.g., "couvertur"), spurious verbs (e.g.,
"villa" → "viller"), and inconsistent case normalization. Large models
produce ~12% fewer unique lemmas through better consolidation, resulting
in cleaner vocabulary lists.

Trade-off: larger download size (~500MB vs ~15MB per model).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
