### PR TITLE
ci: add path filters to skip CI on irrelevant changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/ci.yml'
 
 jobs:
   lint:


### PR DESCRIPTION
Only run CI when Python source, tests, dependencies, or the workflow
itself changes. Documentation-only changes no longer trigger CI.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
