### PR TITLE
docs: streamline CLAUDE.md guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,60 +1,44 @@
 # Project Guidelines
 
 ## Code Style
-- Use typings throughout
-- Code should be free of any typing errors (`mypy .`) and free of any ruff errors
-- Do not use `any` unless absolutely necessary
+- Use typings throughout; code must pass mypy and ruff
 - Use `list[]`, `dict[]` rather than `List[]`, `Dict[]`
+- Avoid `any` unless absolutely necessary
 - Include docstrings in every public-facing method (not required in tests)
-
-## Project Structure
-- Use src-layout: code in `src/`
-- Write tests in `tests/`
+- Use src-layout: code in `src/`, tests in `tests/`
 
 ## Test Coverage
-- Aim to maintain 100% test coverage when practical
+- Aim for 100% coverage when practical; minimum threshold is 90%
 - Don't do excessive work to cover edge cases that provide little value
-- Minimum threshold is 90% (enforced in pyproject.toml)
 
 ## Coverage Badge
-When test coverage changes, update the badge in README.md. Use this color scale:
-- 90%+ → `brightgreen`
-- 80-89% → `green`
-- 70-79% → `yellowgreen`
-- 60-69% → `yellow`
-- 50-59% → `orange`
-- <50% → `red`
+When coverage changes, update the badge in README.md:
+- 90%+ → `brightgreen`, 80-89% → `green`, 70-79% → `yellowgreen`
+- 60-69% → `yellow`, 50-59% → `orange`, <50% → `red`
 
 Format: `![Coverage](https://img.shields.io/badge/coverage-XX%25-COLOR)`
 
 ## Running Commands
-- Always use `uv run` to run Python, pytest, mypy, etc. to ensure the virtualenv is used
-- Examples: `uv run pytest`, `uv run mypy src`, `uv run python script.py`
+- Always use `uv run` to ensure the virtualenv is used
+- Examples: `uv run pytest`, `uv run mypy .`, `uv run python script.py`
 
 ## Dependencies
-- Add dependencies using `uv add <package>`, not by editing pyproject.toml directly
-- Add dev dependencies using `uv add --dev <package>`
+- Add dependencies using `uv add <package>` (use `--dev` for dev dependencies)
 
 ## Git Commits
-- Use conventional commits format: `type(scope): description`
-- Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`
-
-## Warnings and Logging
-- Use the `warnings` module (not `logging` or `print`) for non-fatal issues that callers may want to handle
-- This allows callers to filter/suppress warnings with `warnings.filterwarnings()`
+- Use conventional commits: `type(scope): description`
+- Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`
 
 ## Code Reviews
-When asked for a code review, conduct an **adversarial code review** unless otherwise specified:
+Conduct **adversarial code reviews** unless otherwise specified:
 - Assume the code under review is in the last git commit
-- Focus on finding bugs, edge cases, security issues, and design flaws
-- Be critical and thorough - the goal is to find problems, not validate the code
-- Organize findings by severity (Critical, Moderate, Minor)
+- Focus on bugs, edge cases, security issues, and design flaws
+- Organize findings by severity (Critical, Moderate, Minor) w/unique numbering
 - Include file paths and line numbers for each issue
-- Note design observations that aren't bugs but may warrant discussion
 
 ## Implementation Planning
 
-Use `docs/plan.md` for multi-phase implementation work:
+Use `docs/plan.md` for multi-phase implementation work.
 
 ### When Asked to Plan
 1. Discuss the approach with the user to reach shared understanding
@@ -63,35 +47,30 @@ Use `docs/plan.md` for multi-phase implementation work:
    - Phases broken into single-session chunks
    - Clear deliverables and acceptance criteria per phase
    - Files to create, modify, and delete
-   - Test requirements
-3. Update `README.md` if CLI or usage changes
+3. Update README.md if public API or usage changes
 
 ### When Implementing a Phase
 1. Read `docs/plan.md` to understand the current phase
 2. Implement according to the deliverables and acceptance criteria
-3. Run all acceptance criteria checks (ruff, mypy, pytest, coverage)
-4. Once all checks pass:
-   - Update `docs/plan.md` to mark the phase as complete (add checkmarks to acceptance criteria)
-   - Update `README.md` with any new public APIs, usage examples, or coverage badge changes
-   - Commit all changed files with a conventional commit message
+3. Run all checks (ruff, mypy, pytest with coverage)
+4. Once passing: mark phase complete in plan.md, update README.md, commit
 
-### When Asked for Code Review (During Planning)
-1. Read `docs/plan.md` to understand what was supposed to be implemented
-2. Compare the implementation against the acceptance criteria
-3. Conduct adversarial review focusing on:
-   - Does the implementation match the plan?
-   - Are acceptance criteria actually met?
-   - Bugs, edge cases, security issues
-4. Report any gaps between plan and implementation
+### Code Review During Planning
+1. Compare implementation against plan's acceptance criteria
+2. Conduct adversarial review (match plan? criteria met? bugs?)
+3. Report gaps between plan and implementation
 
 ### Committing Code Review Fixes
-When the user is satisfied with the code review fixes:
-1. Amend the previous phase commit (`git commit --amend --no-edit`)
-2. Do not change the commit message - fixes are refinements, not new scope
-3. Exception: if the fixes substantially change what was implemented, discuss with the user before updating the commit message
+- Amend the previous phase commit (`git commit --amend --no-edit`)
+- Exception: if fixes substantially change scope, discuss with user first
 
-### Continuing Work in New Sessions
-When resuming work on a plan:
-1. Read `docs/plan.md` to understand overall context and current phase
-2. Check git status/log to see what's already been done
-3. Continue from where the previous session left off
+### Continuing Work
+Read `docs/plan.md`, check git status/log, continue from where previous session left off.
+
+### Completing a Plan
+When fully implemented and code reviewed:
+1. Run final quality checks (ruff, mypy, pytest)
+2. Verify README.md accuracy (features, examples, coverage badge, architecture)
+3. Check plan.md for info to preserve (decisions → docstrings, future work → Issues)
+4. Suggest CHANGELOG.md if project will be versioned; otherwise keep docs minimal
+5. Delete `docs/plan.md` and empty `docs/` directory


### PR DESCRIPTION
- Merge Project Structure into Code Style
- Remove library-specific Warnings and Logging section
- Condense verbose phrasing throughout
- Add "Completing a Plan" workflow for closing out implementations
- Simplify "Continuing Work" to single line

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
