### PR TITLE
feat(tokens): add pos and morph fields to Token dataclass

### DIFF
--- a/src/vocab/models.py
+++ b/src/vocab/models.py
@@ -53,12 +53,16 @@ class Token:
 
     Attributes:
         lemma: The lemmatized form of the token.
+        pos: Universal part-of-speech tag (e.g., "NOUN", "VERB").
+        morph: Morphological features as a dictionary (e.g., {"Gender": "Masc"}).
         original: The original text of the token as it appears.
         sentence: The full sentence containing the token.
         location: Location of the sentence within the epub.
     """
 
     lemma: str
+    pos: str
+    morph: dict[str, str]
     original: str
     sentence: str
     location: SentenceLocation

--- a/src/vocab/tokens.py
+++ b/src/vocab/tokens.py
@@ -24,7 +24,8 @@ def extract_tokens(
             symbols, and other non-vocabulary tokens.
 
     Yields:
-        Token objects with lemma, original form, sentence text, and location.
+        Token objects with lemma, original form, POS tag, morphology, sentence
+        text, and location.
 
     Raises:
         SpacyModelNotFoundError: If the spaCy model is not installed.
@@ -54,4 +55,6 @@ def extract_tokens(
             original=token.text,
             sentence=sentence_text,
             location=location,
+            pos=token.pos_,
+            morph=token.morph.to_dict(),
         )

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -64,6 +64,38 @@ class TestExtractTokens:
         assert isinstance(token.original, str)
         assert isinstance(token.sentence, str)
         assert isinstance(token.location, SentenceLocation)
+        assert isinstance(token.pos, str)
+        assert isinstance(token.morph, dict)
+
+    def test_token_pos_from_spacy(
+        self, mock_spacy_model_with_lemmatizer: Language, sample_location: SentenceLocation
+    ) -> None:
+        """Should populate pos from spaCy's pos_ attribute."""
+        sentence = "Ceci est une phrase."
+        with patch("vocab.tokens.get_model", return_value=mock_spacy_model_with_lemmatizer):
+            tokens = list(extract_tokens(sentence, sample_location, "fr"))
+
+        # Blank model returns empty string for pos_, but the field should exist
+        for token in tokens:
+            assert hasattr(token, "pos")
+            assert isinstance(token.pos, str)
+
+    def test_token_morph_from_spacy(
+        self, mock_spacy_model_with_lemmatizer: Language, sample_location: SentenceLocation
+    ) -> None:
+        """Should populate morph from spaCy's morph.to_dict()."""
+        sentence = "Ceci est une phrase."
+        with patch("vocab.tokens.get_model", return_value=mock_spacy_model_with_lemmatizer):
+            tokens = list(extract_tokens(sentence, sample_location, "fr"))
+
+        # Blank model returns empty dict for morph, but the field should exist
+        for token in tokens:
+            assert hasattr(token, "morph")
+            assert isinstance(token.morph, dict)
+            # All keys and values should be strings
+            for key, value in token.morph.items():
+                assert isinstance(key, str)
+                assert isinstance(value, str)
 
     def test_location_is_passed_through(self, mock_spacy_model_with_lemmatizer: Language) -> None:
         """Should use the provided location in all output tokens."""


### PR DESCRIPTION
Add part-of-speech tag and morphological features to Token, populated
from spaCy's pos_ and morph.to_dict() attributes. This enables richer
linguistic analysis for vocabulary processing.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
