### PR TITLE
refactor(dictionary): restructure for sense-level lookups (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vocab
 
-![Coverage](https://img.shields.io/badge/coverage-97%25-brightgreen)
+![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
 
 Extract vocabulary with frequency data from ePub files for language learning.
 

--- a/src/vocab/__init__.py
+++ b/src/vocab/__init__.py
@@ -1,6 +1,12 @@
 """Vocabulary extraction from ePub files."""
 
-from vocab.dictionary import Dictionary, DictionaryEntry
+from vocab.dictionary import (
+    SPACY_TO_KAIKKI,
+    Dictionary,
+    DictionaryEntry,
+    DictionaryExample,
+    DictionarySense,
+)
 from vocab.epub import extract_chapters
 from vocab.models import (
     Chapter,
@@ -19,8 +25,11 @@ __all__ = [
     "Chapter",
     "Dictionary",
     "DictionaryEntry",
+    "DictionaryExample",
+    "DictionarySense",
     "Example",
     "LemmaEntry",
+    "SPACY_TO_KAIKKI",
     "Sentence",
     "SentenceLocation",
     "SpacyModelNotFoundError",


### PR DESCRIPTION
- Add DictionaryExample, DictionarySense dataclasses with from_kaikki()
- Restructure DictionaryEntry to have word, pos, ipa, etymology, senses
- Change lookup() to return list[DictionaryEntry] with POS filtering
- Add SPACY_TO_KAIKKI mapping for POS tag conversion
- Update tests for new API

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
