### PR TITLE
feat(pipeline): implement disambiguation stage (Phase 3)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -661,17 +661,17 @@ asyncio.run(main())
 
 ### Acceptance Criteria
 
-- [ ] `SenseAssignment` dataclass with `lemma`, `examples`, `word`, `sense` fields
-- [ ] `needs_disambiguation()` returns True for multi-word or multi-sense entries
-- [ ] `assign_single_sense()` works for trivial cases
-- [ ] `assign_single_sense()` raises AssertionError for non-trivial cases
-- [ ] `disambiguate_senses()` calls LLM and parses response
-- [ ] `disambiguate_senses()` raises AssertionError for trivial cases
-- [ ] Unassignable examples are logged and omitted
-- [ ] Unit tests mock LLM responses
-- [ ] `uv run ruff check .` passes
-- [ ] `uv run mypy .` passes
-- [ ] `uv run pytest --cov=vocab --cov-fail-under=90` passes
+- [x] `SenseAssignment` dataclass with `lemma`, `examples`, `word`, `sense` fields
+- [x] `needs_disambiguation()` returns True for multi-word or multi-sense entries
+- [x] `assign_single_sense()` works for trivial cases
+- [x] `assign_single_sense()` raises AssertionError for non-trivial cases
+- [x] `disambiguate_senses()` calls LLM and parses response
+- [x] `disambiguate_senses()` raises AssertionError for trivial cases
+- [x] Unassignable examples are logged and omitted
+- [x] Unit tests mock LLM responses
+- [x] `uv run ruff check .` passes
+- [x] `uv run mypy .` passes
+- [x] `uv run pytest --cov=vocab --cov-fail-under=90` passes
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,12 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
+    "anthropic>=0.77.0",
     "beautifulsoup4>=4.14.3",
     "ebooklib>=0.20",
     "httpx>=0.28.1",
     "lxml>=6.0.2",
+    "pydantic>=2.12.5",
     "spacy>=3.8.11",
 ]
 
@@ -24,6 +26,7 @@ dev = [
     "mypy>=1.19.1",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
     "pytest-cov>=6.0.0",
     "ruff>=0.14.14",
 ]
@@ -102,6 +105,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+asyncio_mode = "auto"
 addopts = [
     "-v",
     "--cov=vocab",

--- a/src/vocab/__init__.py
+++ b/src/vocab/__init__.py
@@ -17,7 +17,14 @@ from vocab.models import (
     Token,
     Vocabulary,
 )
-from vocab.pipeline import EnrichedLemma, generate_enriched_lemmas
+from vocab.pipeline import (
+    EnrichedLemma,
+    SenseAssignment,
+    assign_single_sense,
+    disambiguate_senses,
+    generate_enriched_lemmas,
+    needs_disambiguation,
+)
 from vocab.sentences import SpacyModelNotFoundError, extract_sentences
 from vocab.tokens import extract_tokens
 from vocab.vocabulary import build_vocabulary
@@ -33,13 +40,17 @@ __all__ = [
     "LemmaEntry",
     "SPACY_TO_KAIKKI",
     "Sentence",
+    "SenseAssignment",
     "SentenceLocation",
     "SpacyModelNotFoundError",
     "Token",
     "Vocabulary",
+    "assign_single_sense",
     "build_vocabulary",
+    "disambiguate_senses",
     "extract_chapters",
     "extract_sentences",
     "extract_tokens",
     "generate_enriched_lemmas",
+    "needs_disambiguation",
 ]

--- a/src/vocab/pipeline.py
+++ b/src/vocab/pipeline.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 
-from vocab.dictionary import SPACY_TO_KAIKKI, Dictionary, DictionaryEntry
+import anthropic
+from pydantic import BaseModel
+
+from vocab.dictionary import LANGUAGE_NAMES, SPACY_TO_KAIKKI, Dictionary, DictionaryEntry
 from vocab.models import LemmaEntry, Vocabulary
+
+logger = logging.getLogger(__name__)
+
+# Model name mapping
+MODEL_MAPPING: dict[str, str] = {
+    "claude-haiku": "claude-3-5-haiku-latest",
+    "claude-sonnet": "claude-sonnet-4-20250514",
+}
 
 
 @dataclass
@@ -25,6 +37,46 @@ class EnrichedLemma:
         """Validate invariants."""
         if not self.words:
             raise ValueError("words must have at least one entry")
+        if any(not word.senses for word in self.words):
+            raise ValueError("all words must have at least one sense")
+
+
+@dataclass
+class SenseAssignment:
+    """A sense assignment mapping examples to a specific dictionary sense.
+
+    Attributes:
+        lemma: The LemmaEntry from the vocabulary.
+        examples: Indices into lemma.examples[].
+        word: The DictionaryEntry containing the matched sense.
+        sense: Index into word.senses[].
+    """
+
+    lemma: LemmaEntry
+    examples: list[int]
+    word: DictionaryEntry
+    sense: int
+
+    def __post_init__(self) -> None:
+        """Validate invariants."""
+        if self.sense < 0 or self.sense >= len(self.word.senses):
+            raise ValueError(f"sense index {self.sense} out of bounds")
+        for idx in self.examples:
+            if idx < 0 or idx >= len(self.lemma.examples):
+                raise ValueError(f"example index {idx} out of bounds")
+
+
+class SentenceAssignment(BaseModel):
+    """Assignment of a sentence to a sense."""
+
+    sentence: int  # 1-indexed sentence number
+    sense: int | None  # 1-indexed sense number, None if unknown
+
+
+class DisambiguationResponse(BaseModel):
+    """LLM response for sense disambiguation."""
+
+    assignments: list[SentenceAssignment]
 
 
 def generate_enriched_lemmas(
@@ -49,3 +101,221 @@ def generate_enriched_lemmas(
             words = dictionary.lookup(lemma_entry.lemma, pos=kaikki_pos or None)
             if words:
                 yield EnrichedLemma(lemma=lemma_entry, words=words)
+
+
+def needs_disambiguation(entry: EnrichedLemma) -> bool:
+    """Return True if LLM disambiguation is needed.
+
+    Disambiguation is needed when there are multiple words or
+    any word has multiple senses.
+
+    Args:
+        entry: EnrichedLemma to check.
+
+    Returns:
+        True if disambiguation is needed, False otherwise.
+    """
+    if len(entry.words) > 1:
+        return True
+    return len(entry.words[0].senses) > 1
+
+
+def assign_single_sense(entry: EnrichedLemma) -> SenseAssignment:
+    """Assign all examples to the single available sense.
+
+    Args:
+        entry: EnrichedLemma with exactly one word and one sense.
+
+    Returns:
+        SenseAssignment with all example indices.
+
+    Raises:
+        AssertionError: If entry has multiple words or senses.
+    """
+    assert not needs_disambiguation(entry), "Use disambiguate_senses() for this entry"
+    return SenseAssignment(
+        lemma=entry.lemma,
+        examples=list(range(len(entry.lemma.examples))),
+        word=entry.words[0],
+        sense=0,
+    )
+
+
+def _build_prompt(entry: EnrichedLemma, language: str) -> str:
+    """Build the disambiguation prompt for the LLM.
+
+    Args:
+        entry: EnrichedLemma with multiple words or senses.
+        language: Full language name (e.g., "French").
+
+    Returns:
+        Formatted prompt string.
+    """
+    # Build senses list
+    senses_lines: list[str] = []
+    sense_idx = 1
+    for word in entry.words:
+        for sense in word.senses:
+            etymology = word.etymology or "unknown"
+            senses_lines.append(
+                f"{sense_idx}. [word={word.word}, etymology={etymology}] {sense.translation}"
+            )
+            sense_idx += 1
+
+    # Build sentences list
+    sentences_lines: list[str] = []
+    for i, example in enumerate(entry.lemma.examples, 1):
+        sentences_lines.append(f"{i}. {example.sentence}")
+
+    return f"""You are helping associate sentences with word meanings.
+
+Language: {language}
+Word: {entry.lemma.lemma}
+
+Available senses:
+{chr(10).join(senses_lines)}
+
+Sentences from the source text:
+{chr(10).join(sentences_lines)}
+
+For each sentence, indicate which sense is being used.
+If you cannot confidently determine the sense, use null for the sense."""
+
+
+def _parse_llm_response(
+    response: DisambiguationResponse,
+    entry: EnrichedLemma,
+) -> list[SenseAssignment]:
+    """Parse LLM response into SenseAssignments.
+
+    Args:
+        response: Parsed LLM response.
+        entry: EnrichedLemma being disambiguated.
+
+    Returns:
+        List of SenseAssignments, one per unique (word, sense) used.
+    """
+    # Build flat list of (word_idx, word, sense_idx) for 1-indexed sense numbers
+    sense_map: list[tuple[int, DictionaryEntry, int]] = []
+    for word_idx, word in enumerate(entry.words):
+        for sense_idx in range(len(word.senses)):
+            sense_map.append((word_idx, word, sense_idx))
+
+    # Group examples by (word, sense)
+    assignments_by_sense: dict[tuple[int, int], list[int]] = {}
+
+    for assignment in response.assignments:
+        if assignment.sense is None:
+            logger.warning(
+                "Could not disambiguate sentence %d for %s",
+                assignment.sentence,
+                entry.lemma.lemma,
+            )
+            continue
+
+        # Convert 1-indexed to 0-indexed
+        sentence_idx = assignment.sentence - 1
+        sense_idx = assignment.sense - 1
+
+        if sense_idx < 0 or sense_idx >= len(sense_map):
+            logger.warning(
+                "Invalid sense %d for %s (max %d)",
+                assignment.sense,
+                entry.lemma.lemma,
+                len(sense_map),
+            )
+            continue
+
+        if sentence_idx < 0 or sentence_idx >= len(entry.lemma.examples):
+            logger.warning(
+                "Invalid sentence %d for %s (max %d)",
+                assignment.sentence,
+                entry.lemma.lemma,
+                len(entry.lemma.examples),
+            )
+            continue
+
+        # Find which word this sense belongs to
+        word_idx, _, local_sense_idx = sense_map[sense_idx]
+
+        key = (word_idx, local_sense_idx)
+        if key not in assignments_by_sense:
+            assignments_by_sense[key] = []
+        assignments_by_sense[key].append(sentence_idx)
+
+    # Convert to SenseAssignments
+    results: list[SenseAssignment] = []
+    for (word_idx, sense_idx), examples in assignments_by_sense.items():
+        results.append(
+            SenseAssignment(
+                lemma=entry.lemma,
+                examples=examples,
+                word=entry.words[word_idx],
+                sense=sense_idx,
+            )
+        )
+
+    return results
+
+
+async def disambiguate_senses(
+    entry: EnrichedLemma,
+    *,
+    language: str,
+    model: str = "claude-haiku",
+) -> list[SenseAssignment]:
+    """Use LLM to assign examples to senses.
+
+    This function's signature is provider-agnostic: domain types in, domain
+    types out. The LLM provider (currently Anthropic) is an implementation
+    detail; switching providers requires only changing this function's internals.
+
+    Args:
+        entry: EnrichedLemma with multiple words or senses.
+        language: Two-letter language code (e.g., "fr").
+        model: Model identifier ("claude-haiku" or "claude-sonnet").
+
+    Returns:
+        List of SenseAssignments, one per unique (word, sense) used.
+        Examples that couldn't be assigned are logged and omitted.
+
+    Raises:
+        AssertionError: If entry has only one sense.
+        ValueError: If language code is not recognized.
+    """
+    assert needs_disambiguation(entry), "Use assign_single_sense() for this entry"
+
+    # Resolve language name from code
+    if language not in LANGUAGE_NAMES:
+        raise ValueError(f"Unknown language code: {language}")
+    language_name = LANGUAGE_NAMES[language]
+
+    # Build prompt
+    prompt = _build_prompt(entry, language_name)
+
+    # Call LLM
+    model_id = MODEL_MAPPING.get(model, model)
+    client = anthropic.AsyncAnthropic()
+
+    message = await client.messages.create(
+        model=model_id,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": prompt}],
+        tools=[
+            {
+                "name": "submit_assignments",
+                "description": "Submit the sense assignments for each sentence",
+                "input_schema": DisambiguationResponse.model_json_schema(),
+            }
+        ],
+        tool_choice={"type": "tool", "name": "submit_assignments"},
+    )
+
+    # Extract tool call result
+    for block in message.content:
+        if block.type == "tool_use" and block.name == "submit_assignments":
+            response = DisambiguationResponse.model_validate(block.input)
+            return _parse_llm_response(response, entry)
+
+    logger.warning("No tool call in LLM response for %s", entry.lemma.lemma)
+    return []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,23 @@
 """Tests for the pipeline module."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from vocab.dictionary import DictionaryEntry, DictionarySense
 from vocab.models import Example, LemmaEntry, SentenceLocation, Vocabulary
-from vocab.pipeline import EnrichedLemma, generate_enriched_lemmas
+from vocab.pipeline import (
+    DisambiguationResponse,
+    EnrichedLemma,
+    SenseAssignment,
+    SentenceAssignment,
+    _build_prompt,
+    _parse_llm_response,
+    assign_single_sense,
+    disambiguate_senses,
+    generate_enriched_lemmas,
+    needs_disambiguation,
+)
 
 
 def make_lemma_entry(
@@ -74,6 +87,14 @@ class TestEnrichedLemma:
 
         with pytest.raises(ValueError, match="words must have at least one entry"):
             EnrichedLemma(lemma=lemma, words=[])
+
+    def test_rejects_words_with_no_senses(self) -> None:
+        """Test that EnrichedLemma rejects words with zero senses."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        words = [make_dictionary_entry_no_senses("chien", "noun")]
+
+        with pytest.raises(ValueError, match="all words must have at least one sense"):
+            EnrichedLemma(lemma=lemma, words=words)
 
 
 class TestGenerateEnrichedLemmas:
@@ -246,3 +267,424 @@ class TestGenerateEnrichedLemmas:
         call_args = mock_dict.lookup.call_args
         assert call_args[0][0] == "dans"
         assert set(call_args[1]["pos"]) == {"prep", "prep_phrase", "postp"}
+
+
+def make_lemma_with_examples(
+    lemma: str,
+    pos: str,
+    sentences: list[str],
+) -> LemmaEntry:
+    """Create a LemmaEntry with multiple examples."""
+    return LemmaEntry(
+        lemma=lemma,
+        pos=pos,
+        frequency=len(sentences),
+        forms={lemma: len(sentences)},
+        examples=[
+            Example(
+                sentence=s,
+                location=SentenceLocation(
+                    chapter_index=0,
+                    chapter_title="Chapter 1",
+                    sentence_index=i,
+                ),
+            )
+            for i, s in enumerate(sentences)
+        ],
+    )
+
+
+def make_dictionary_entry_with_senses(
+    word: str,
+    pos: str,
+    translations: list[str],
+    etymology: str | None = None,
+) -> DictionaryEntry:
+    """Create a DictionaryEntry with multiple senses."""
+    return DictionaryEntry(
+        word=word,
+        pos=pos,
+        ipa="/test/",
+        etymology=etymology,
+        senses=[
+            DictionarySense(
+                id=f"{word}-{pos}-{i}",
+                translation=t,
+                example=None,
+            )
+            for i, t in enumerate(translations)
+        ],
+    )
+
+
+def make_dictionary_entry_no_senses(word: str, pos: str) -> DictionaryEntry:
+    """Create a DictionaryEntry with zero senses (malformed data)."""
+    return DictionaryEntry(
+        word=word,
+        pos=pos,
+        ipa="/test/",
+        etymology=None,
+        senses=[],
+    )
+
+
+class TestSenseAssignment:
+    """Tests for SenseAssignment dataclass."""
+
+    def test_has_required_fields(self) -> None:
+        """Test SenseAssignment has required fields."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        word = make_dictionary_entry("chien", "noun", "dog")
+
+        assignment = SenseAssignment(
+            lemma=lemma,
+            examples=[0],
+            word=word,
+            sense=0,
+        )
+
+        assert assignment.lemma == lemma
+        assert assignment.examples == [0]
+        assert assignment.word == word
+        assert assignment.sense == 0
+
+    def test_rejects_invalid_sense_index(self) -> None:
+        """Test that SenseAssignment rejects sense index out of bounds."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        word = make_dictionary_entry("chien", "noun", "dog")  # has 1 sense (index 0)
+
+        with pytest.raises(ValueError, match="sense index 1 out of bounds"):
+            SenseAssignment(lemma=lemma, examples=[0], word=word, sense=1)
+
+    def test_rejects_negative_sense_index(self) -> None:
+        """Test that SenseAssignment rejects negative sense index."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        word = make_dictionary_entry("chien", "noun", "dog")
+
+        with pytest.raises(ValueError, match="sense index -1 out of bounds"):
+            SenseAssignment(lemma=lemma, examples=[0], word=word, sense=-1)
+
+    def test_rejects_invalid_example_index(self) -> None:
+        """Test that SenseAssignment rejects example index out of bounds."""
+        lemma = make_lemma_entry("chien", "NOUN")  # has 1 example (index 0)
+        word = make_dictionary_entry("chien", "noun", "dog")
+
+        with pytest.raises(ValueError, match="example index 1 out of bounds"):
+            SenseAssignment(lemma=lemma, examples=[0, 1], word=word, sense=0)
+
+    def test_rejects_negative_example_index(self) -> None:
+        """Test that SenseAssignment rejects negative example index."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        word = make_dictionary_entry("chien", "noun", "dog")
+
+        with pytest.raises(ValueError, match="example index -1 out of bounds"):
+            SenseAssignment(lemma=lemma, examples=[-1], word=word, sense=0)
+
+
+class TestNeedsDisambiguation:
+    """Tests for needs_disambiguation function."""
+
+    def test_single_word_single_sense_returns_false(self) -> None:
+        """Test that single word with single sense doesn't need disambiguation."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        words = [make_dictionary_entry("chien", "noun", "dog")]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        assert needs_disambiguation(entry) is False
+
+    def test_multiple_words_returns_true(self) -> None:
+        """Test that multiple words need disambiguation."""
+        lemma = make_lemma_entry("faux", "NOUN")
+        words = [
+            make_dictionary_entry("faux", "noun", "forgery"),
+            make_dictionary_entry("faux", "noun", "scythe"),
+        ]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        assert needs_disambiguation(entry) is True
+
+    def test_single_word_multiple_senses_returns_true(self) -> None:
+        """Test that single word with multiple senses needs disambiguation."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        words = [make_dictionary_entry_with_senses("chien", "noun", ["dog", "hammer"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        assert needs_disambiguation(entry) is True
+
+
+class TestAssignSingleSense:
+    """Tests for assign_single_sense function."""
+
+    def test_assigns_all_examples_to_single_sense(self) -> None:
+        """Test that all examples are assigned to the single sense."""
+        lemma = make_lemma_with_examples("chien", "NOUN", ["Le chien aboie.", "Mon chien dort."])
+        words = [make_dictionary_entry("chien", "noun", "dog")]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        assignment = assign_single_sense(entry)
+
+        assert assignment.lemma == lemma
+        assert assignment.examples == [0, 1]
+        assert assignment.word == words[0]
+        assert assignment.sense == 0
+
+    def test_raises_for_multi_sense_entry(self) -> None:
+        """Test that AssertionError is raised for multi-sense entries."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        words = [make_dictionary_entry_with_senses("chien", "noun", ["dog", "hammer"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        with pytest.raises(AssertionError, match="Use disambiguate_senses"):
+            assign_single_sense(entry)
+
+    def test_raises_for_multi_word_entry(self) -> None:
+        """Test that AssertionError is raised for multi-word entries."""
+        lemma = make_lemma_entry("faux", "NOUN")
+        words = [
+            make_dictionary_entry("faux", "noun", "forgery"),
+            make_dictionary_entry("faux", "noun", "scythe"),
+        ]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        with pytest.raises(AssertionError, match="Use disambiguate_senses"):
+            assign_single_sense(entry)
+
+
+class TestBuildPrompt:
+    """Tests for _build_prompt function."""
+
+    def test_builds_prompt_with_single_word_multiple_senses(self) -> None:
+        """Test prompt building with multiple senses."""
+        lemma = make_lemma_with_examples("chien", "NOUN", ["Le chien aboie."])
+        words = [
+            make_dictionary_entry_with_senses(
+                "chien", "noun", ["dog", "hammer"], etymology="From Latin canis"
+            )
+        ]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        prompt = _build_prompt(entry, "French")
+
+        assert "Language: French" in prompt
+        assert "Word: chien" in prompt
+        assert "1. [word=chien, etymology=From Latin canis] dog" in prompt
+        assert "2. [word=chien, etymology=From Latin canis] hammer" in prompt
+        assert "1. Le chien aboie." in prompt
+
+    def test_builds_prompt_with_multiple_words(self) -> None:
+        """Test prompt building with multiple words."""
+        lemma = make_lemma_with_examples("faux", "NOUN", ["Un faux document."])
+        words = [
+            make_dictionary_entry_with_senses(
+                "faux", "noun", ["forgery"], etymology="From Latin falsus"
+            ),
+            make_dictionary_entry_with_senses(
+                "faux", "noun", ["scythe"], etymology="From Latin falx"
+            ),
+        ]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        prompt = _build_prompt(entry, "French")
+
+        assert "1. [word=faux, etymology=From Latin falsus] forgery" in prompt
+        assert "2. [word=faux, etymology=From Latin falx] scythe" in prompt
+
+    def test_uses_unknown_for_missing_etymology(self) -> None:
+        """Test that missing etymology shows as 'unknown'."""
+        lemma = make_lemma_with_examples("test", "NOUN", ["A test."])
+        words = [make_dictionary_entry_with_senses("test", "noun", ["a test"], etymology=None)]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        prompt = _build_prompt(entry, "French")
+
+        assert "etymology=unknown" in prompt
+
+
+class TestParseLlmResponse:
+    """Tests for _parse_llm_response function."""
+
+    def test_parses_valid_response(self) -> None:
+        """Test parsing a valid LLM response."""
+        lemma = make_lemma_with_examples("faux", "NOUN", ["Doc faux.", "La faux."])
+        words = [
+            make_dictionary_entry_with_senses("faux", "noun", ["forgery"]),
+            make_dictionary_entry_with_senses("faux", "noun", ["scythe"]),
+        ]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        response = DisambiguationResponse(
+            assignments=[
+                SentenceAssignment(sentence=1, sense=1),  # forgery
+                SentenceAssignment(sentence=2, sense=2),  # scythe
+            ]
+        )
+
+        results = _parse_llm_response(response, entry)
+
+        assert len(results) == 2
+        # Check first assignment (forgery)
+        forgery_assignment = next(r for r in results if r.word.senses[0].translation == "forgery")
+        assert forgery_assignment.examples == [0]
+        assert forgery_assignment.sense == 0
+
+        # Check second assignment (scythe)
+        scythe_assignment = next(r for r in results if r.word.senses[0].translation == "scythe")
+        assert scythe_assignment.examples == [1]
+        assert scythe_assignment.sense == 0
+
+    def test_groups_examples_by_sense(self) -> None:
+        """Test that multiple examples for same sense are grouped."""
+        lemma = make_lemma_with_examples("chien", "NOUN", ["Le chien 1.", "Le chien 2."])
+        words = [make_dictionary_entry_with_senses("chien", "noun", ["dog", "hammer"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        response = DisambiguationResponse(
+            assignments=[
+                SentenceAssignment(sentence=1, sense=1),  # both are dogs
+                SentenceAssignment(sentence=2, sense=1),
+            ]
+        )
+
+        results = _parse_llm_response(response, entry)
+
+        assert len(results) == 1
+        assert results[0].examples == [0, 1]
+        assert results[0].sense == 0  # dog sense
+
+    def test_skips_null_sense(self) -> None:
+        """Test that null senses are skipped with warning."""
+        lemma = make_lemma_with_examples("test", "NOUN", ["Test sentence."])
+        words = [make_dictionary_entry_with_senses("test", "noun", ["a test"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        response = DisambiguationResponse(assignments=[SentenceAssignment(sentence=1, sense=None)])
+
+        results = _parse_llm_response(response, entry)
+
+        assert len(results) == 0
+
+    def test_skips_invalid_sense_number(self) -> None:
+        """Test that invalid sense numbers are skipped."""
+        lemma = make_lemma_with_examples("test", "NOUN", ["Test sentence."])
+        words = [make_dictionary_entry_with_senses("test", "noun", ["a test"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        response = DisambiguationResponse(
+            assignments=[SentenceAssignment(sentence=1, sense=99)]  # Invalid
+        )
+
+        results = _parse_llm_response(response, entry)
+
+        assert len(results) == 0
+
+    def test_skips_invalid_sentence_number(self) -> None:
+        """Test that invalid sentence numbers are skipped."""
+        lemma = make_lemma_with_examples("test", "NOUN", ["Test sentence."])
+        words = [make_dictionary_entry_with_senses("test", "noun", ["a test"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        response = DisambiguationResponse(
+            assignments=[SentenceAssignment(sentence=99, sense=1)]  # Invalid
+        )
+
+        results = _parse_llm_response(response, entry)
+
+        assert len(results) == 0
+
+
+class TestDisambiguateSenses:
+    """Tests for disambiguate_senses async function."""
+
+    @pytest.mark.asyncio
+    async def test_raises_for_trivial_entry(self) -> None:
+        """Test that AssertionError is raised for trivial entries."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        words = [make_dictionary_entry("chien", "noun", "dog")]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        with pytest.raises(AssertionError, match="Use assign_single_sense"):
+            await disambiguate_senses(entry, language="fr")
+
+    @pytest.mark.asyncio
+    async def test_raises_for_unknown_language_code(self) -> None:
+        """Test that ValueError is raised for unknown language codes."""
+        lemma = make_lemma_entry("chien", "NOUN")
+        words = [make_dictionary_entry_with_senses("chien", "noun", ["dog", "hammer"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        with pytest.raises(ValueError, match="Unknown language code: xyz"):
+            await disambiguate_senses(entry, language="xyz")
+
+    @pytest.mark.asyncio
+    async def test_calls_llm_and_parses_response(self) -> None:
+        """Test that LLM is called and response is parsed."""
+        lemma = make_lemma_with_examples("faux", "NOUN", ["Doc faux."])
+        words = [
+            make_dictionary_entry_with_senses("faux", "noun", ["forgery"]),
+            make_dictionary_entry_with_senses("faux", "noun", ["scythe"]),
+        ]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        # Mock the Anthropic client
+        mock_tool_use = MagicMock()
+        mock_tool_use.type = "tool_use"
+        mock_tool_use.name = "submit_assignments"
+        mock_tool_use.input = {"assignments": [{"sentence": 1, "sense": 1}]}
+
+        mock_message = MagicMock()
+        mock_message.content = [mock_tool_use]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+        with patch("vocab.pipeline.anthropic.AsyncAnthropic", return_value=mock_client):
+            results = await disambiguate_senses(entry, language="fr")
+
+        assert len(results) == 1
+        assert results[0].examples == [0]
+        mock_client.messages.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_uses_correct_model_mapping(self) -> None:
+        """Test that model names are mapped correctly."""
+        lemma = make_lemma_with_examples("test", "NOUN", ["Test."])
+        words = [make_dictionary_entry_with_senses("test", "noun", ["a", "b"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        mock_tool_use = MagicMock()
+        mock_tool_use.type = "tool_use"
+        mock_tool_use.name = "submit_assignments"
+        mock_tool_use.input = {"assignments": [{"sentence": 1, "sense": 1}]}
+
+        mock_message = MagicMock()
+        mock_message.content = [mock_tool_use]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+        with patch("vocab.pipeline.anthropic.AsyncAnthropic", return_value=mock_client):
+            await disambiguate_senses(entry, language="fr", model="claude-haiku")
+
+        call_kwargs = mock_client.messages.create.call_args[1]
+        assert call_kwargs["model"] == "claude-3-5-haiku-latest"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_tool_call(self) -> None:
+        """Test that empty list is returned when LLM doesn't use tool."""
+        lemma = make_lemma_with_examples("test", "NOUN", ["Test."])
+        words = [make_dictionary_entry_with_senses("test", "noun", ["a", "b"])]
+        entry = EnrichedLemma(lemma=lemma, words=words)
+
+        mock_text = MagicMock()
+        mock_text.type = "text"
+
+        mock_message = MagicMock()
+        mock_message.content = [mock_text]
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_message)
+
+        with patch("vocab.pipeline.anthropic.AsyncAnthropic", return_value=mock_client):
+            results = await disambiguate_senses(entry, language="fr")
+
+        assert results == []

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.77.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/85/6cb5da3cf91de2eeea89726316e8c5c8c31e2d61ee7cb1233d7e95512c31/anthropic-0.77.0.tar.gz", hash = "sha256:ce36efeb80cb1e25430a88440dc0f9aa5c87f10d080ab70a1bdfd5c2c5fbedb4", size = 504575, upload-time = "2026-01-29T18:20:41.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/27/9df785d3f94df9ac72f43ee9e14b8120b37d992b18f4952774ed46145022/anthropic-0.77.0-py3-none-any.whl", hash = "sha256:65cc83a3c82ce622d5c677d0d7706c77d29dc83958c6b10286e12fda6ffb2651", size = 397867, upload-time = "2026-01-29T18:20:39.481Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -328,6 +347,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
 name = "ebooklib"
 version = "0.20"
 source = { registry = "https://pypi.org/simple" }
@@ -423,6 +460,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c9/5b9f7b4983f1b542c64e84165075335e8a236fa9e2ea03a0c79780062be8/jiter-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:305e061fa82f4680607a775b2e8e0bcb071cd2205ac38e6ef48c8dd5ebe1cf37", size = 314449, upload-time = "2025-11-09T20:47:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/e8efa0e78de00db0aee82c0cf9e8b3f2027efd7f8a71f859d8f4be8e98ef/jiter-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c1860627048e302a528333c9307c818c547f214d8659b0705d2195e1a94b274", size = 319855, upload-time = "2025-11-09T20:47:24.779Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/894cd88e60b5d58af53bec5c6759d1292bd0b37a8b5f60f07abf7a63ae5f/jiter-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df37577a4f8408f7e0ec3205d2a8f87672af8f17008358063a4d6425b6081ce3", size = 350171, upload-time = "2025-11-09T20:47:26.469Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/27/a7b818b9979ac31b3763d25f3653ec3a954044d5e9f5d87f2f247d679fd1/jiter-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fdd787356c1c13a4f40b43c2156276ef7a71eb487d98472476476d803fb2cf", size = 365590, upload-time = "2025-11-09T20:47:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7e/e46195801a97673a83746170b17984aa8ac4a455746354516d02ca5541b4/jiter-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eb5db8d9c65b112aacf14fcd0faae9913d07a8afea5ed06ccdd12b724e966a1", size = 479462, upload-time = "2025-11-09T20:47:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/f833bfb009ab4bd11b1c9406d333e3b4357709ed0570bb48c7c06d78c7dd/jiter-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73c568cc27c473f82480abc15d1301adf333a7ea4f2e813d6a2c7d8b6ba8d0df", size = 378983, upload-time = "2025-11-09T20:47:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b3/7a69d77943cc837d30165643db753471aff5df39692d598da880a6e51c24/jiter-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4321e8a3d868919bcb1abb1db550d41f2b5b326f72df29e53b2df8b006eb9403", size = 361328, upload-time = "2025-11-09T20:47:33.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/a78f90caf48d65ba70d8c6efc6f23150bc39dc3389d65bbec2a95c7bc628/jiter-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a51bad79f8cc9cac2b4b705039f814049142e0050f30d91695a2d9a6611f126", size = 386740, upload-time = "2025-11-09T20:47:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/5d31c2cc8e1b6a6bcf3c5721e4ca0a3633d1ab4754b09bc7084f6c4f5327/jiter-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2a67b678f6a5f1dd6c36d642d7db83e456bc8b104788262aaefc11a22339f5a9", size = 520875, upload-time = "2025-11-09T20:47:36.058Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b5/4df540fae4e9f68c54b8dab004bd8c943a752f0b00efd6e7d64aa3850339/jiter-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efe1a211fe1fd14762adea941e3cfd6c611a136e28da6c39272dbb7a1bbe6a86", size = 511457, upload-time = "2025-11-09T20:47:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/07/65/86b74010e450a1a77b2c1aabb91d4a91dd3cd5afce99f34d75fd1ac64b19/jiter-0.12.0-cp312-cp312-win32.whl", hash = "sha256:d779d97c834b4278276ec703dc3fc1735fca50af63eb7262f05bdb4e62203d44", size = 204546, upload-time = "2025-11-09T20:47:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/6659f537f9562d963488e3e55573498a442503ced01f7e169e96a6110383/jiter-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8269062060212b373316fe69236096aaf4c49022d267c6736eebd66bbbc60bb", size = 205196, upload-time = "2025-11-09T20:47:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f4/935304f5169edadfec7f9c01eacbce4c90bb9a82035ac1de1f3bd2d40be6/jiter-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:06cb970936c65de926d648af0ed3d21857f026b1cf5525cb2947aa5e01e05789", size = 186100, upload-time = "2025-11-09T20:47:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a6/97209693b177716e22576ee1161674d1d58029eb178e01866a0422b69224/jiter-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6cc49d5130a14b732e0612bc76ae8db3b49898732223ef8b7599aa8d9810683e", size = 313658, upload-time = "2025-11-09T20:47:44.424Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4d/125c5c1537c7d8ee73ad3d530a442d6c619714b95027143f1b61c0b4dfe0/jiter-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37f27a32ce36364d2fa4f7fdc507279db604d27d239ea2e044c8f148410defe1", size = 318605, upload-time = "2025-11-09T20:47:45.973Z" },
+    { url = "https://files.pythonhosted.org/packages/99/bf/a840b89847885064c41a5f52de6e312e91fa84a520848ee56c97e4fa0205/jiter-0.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbc0944aa3d4b4773e348cda635252824a78f4ba44328e042ef1ff3f6080d1cf", size = 349803, upload-time = "2025-11-09T20:47:47.535Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/88/e63441c28e0db50e305ae23e19c1d8fae012d78ed55365da392c1f34b09c/jiter-0.12.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da25c62d4ee1ffbacb97fac6dfe4dcd6759ebdc9015991e92a6eae5816287f44", size = 365120, upload-time = "2025-11-09T20:47:49.284Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7c/49b02714af4343970eb8aca63396bc1c82fa01197dbb1e9b0d274b550d4e/jiter-0.12.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:048485c654b838140b007390b8182ba9774621103bd4d77c9c3f6f117474ba45", size = 479918, upload-time = "2025-11-09T20:47:50.807Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ba/0a809817fdd5a1db80490b9150645f3aae16afad166960bcd562be194f3b/jiter-0.12.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:635e737fbb7315bef0037c19b88b799143d2d7d3507e61a76751025226b3ac87", size = 379008, upload-time = "2025-11-09T20:47:52.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/c9fc0232e736c8877d9e6d83d6eeb0ba4e90c6c073835cc2e8f73fdeef51/jiter-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e017c417b1ebda911bd13b1e40612704b1f5420e30695112efdbed8a4b389ed", size = 361785, upload-time = "2025-11-09T20:47:53.512Z" },
+    { url = "https://files.pythonhosted.org/packages/96/61/61f69b7e442e97ca6cd53086ddc1cf59fb830549bc72c0a293713a60c525/jiter-0.12.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:89b0bfb8b2bf2351fba36bb211ef8bfceba73ef58e7f0c68fb67b5a2795ca2f9", size = 386108, upload-time = "2025-11-09T20:47:54.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2e/76bb3332f28550c8f1eba3bf6e5efe211efda0ddbbaf24976bc7078d42a5/jiter-0.12.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f5aa5427a629a824a543672778c9ce0c5e556550d1569bb6ea28a85015287626", size = 519937, upload-time = "2025-11-09T20:47:56.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d6/fa96efa87dc8bff2094fb947f51f66368fa56d8d4fc9e77b25d7fbb23375/jiter-0.12.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed53b3d6acbcb0fd0b90f20c7cb3b24c357fe82a3518934d4edfa8c6898e498c", size = 510853, upload-time = "2025-11-09T20:47:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/28/93f67fdb4d5904a708119a6ab58a8f1ec226ff10a94a282e0215402a8462/jiter-0.12.0-cp313-cp313-win32.whl", hash = "sha256:4747de73d6b8c78f2e253a2787930f4fffc68da7fa319739f57437f95963c4de", size = 204699, upload-time = "2025-11-09T20:47:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1f/30b0eb087045a0abe2a5c9c0c0c8da110875a1d3be83afd4a9a4e548be3c/jiter-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:e25012eb0c456fcc13354255d0338cd5397cce26c77b2832b3c4e2e255ea5d9a", size = 204258, upload-time = "2025-11-09T20:48:01.01Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f4/2b4daf99b96bce6fc47971890b14b2a36aef88d7beb9f057fafa032c6141/jiter-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:c97b92c54fe6110138c872add030a1f99aea2401ddcdaa21edf74705a646dd60", size = 185503, upload-time = "2025-11-09T20:48:02.35Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/67bb15a7061d6fe20b9b2a2fd783e296a1e0f93468252c093481a2f00efa/jiter-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53839b35a38f56b8be26a7851a48b89bc47e5d88e900929df10ed93b95fea3d6", size = 317965, upload-time = "2025-11-09T20:48:03.783Z" },
+    { url = "https://files.pythonhosted.org/packages/18/af/1788031cd22e29c3b14bc6ca80b16a39a0b10e611367ffd480c06a259831/jiter-0.12.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f669548e55c91ab47fef8bddd9c954dab1938644e715ea49d7e117015110a4", size = 345831, upload-time = "2025-11-09T20:48:05.55Z" },
+    { url = "https://files.pythonhosted.org/packages/05/17/710bf8472d1dff0d3caf4ced6031060091c1320f84ee7d5dcbed1f352417/jiter-0.12.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351d54f2b09a41600ffea43d081522d792e81dcfb915f6d2d242744c1cc48beb", size = 361272, upload-time = "2025-11-09T20:48:06.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/1dcc4618b59761fef92d10bcbb0b038b5160be653b003651566a185f1a5c/jiter-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2a5e90604620f94bf62264e7c2c038704d38217b7465b863896c6d7c902b06c7", size = 204604, upload-time = "2025-11-09T20:48:08.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/32/63cb1d9f1c5c6632a783c0052cde9ef7ba82688f7065e2f0d5f10a7e3edb/jiter-0.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:88ef757017e78d2860f96250f9393b7b577b06a956ad102c29c8237554380db3", size = 185628, upload-time = "2025-11-09T20:48:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/45c9f0dbe4a1416b2b9a8a6d1236459540f43d7fb8883cff769a8db0612d/jiter-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c46d927acd09c67a9fb1416df45c5a04c27e83aae969267e98fba35b74e99525", size = 312478, upload-time = "2025-11-09T20:48:10.898Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a7/54ae75613ba9e0f55fcb0bc5d1f807823b5167cc944e9333ff322e9f07dd/jiter-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:774ff60b27a84a85b27b88cd5583899c59940bcc126caca97eb2a9df6aa00c49", size = 318706, upload-time = "2025-11-09T20:48:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/2aa241ad2c10774baf6c37f8b8e1f39c07db358f1329f4eb40eba179c2a2/jiter-0.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5433fab222fb072237df3f637d01b81f040a07dcac1cb4a5c75c7aa9ed0bef1", size = 351894, upload-time = "2025-11-09T20:48:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4f/0f2759522719133a9042781b18cc94e335b6d290f5e2d3e6899d6af933e3/jiter-0.12.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8c593c6e71c07866ec6bfb790e202a833eeec885022296aff6b9e0b92d6a70e", size = 365714, upload-time = "2025-11-09T20:48:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6f/806b895f476582c62a2f52c453151edd8a0fde5411b0497baaa41018e878/jiter-0.12.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90d32894d4c6877a87ae00c6b915b609406819dce8bc0d4e962e4de2784e567e", size = 478989, upload-time = "2025-11-09T20:48:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6c/012d894dc6e1033acd8db2b8346add33e413ec1c7c002598915278a37f79/jiter-0.12.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:798e46eed9eb10c3adbbacbd3bdb5ecd4cf7064e453d00dbef08802dae6937ff", size = 378615, upload-time = "2025-11-09T20:48:18.614Z" },
+    { url = "https://files.pythonhosted.org/packages/87/30/d718d599f6700163e28e2c71c0bbaf6dace692e7df2592fd793ac9276717/jiter-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3f1368f0a6719ea80013a4eb90ba72e75d7ea67cfc7846db2ca504f3df0169a", size = 364745, upload-time = "2025-11-09T20:48:20.117Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/85/315b45ce4b6ddc7d7fceca24068543b02bdc8782942f4ee49d652e2cc89f/jiter-0.12.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65f04a9d0b4406f7e51279710b27484af411896246200e461d80d3ba0caa901a", size = 386502, upload-time = "2025-11-09T20:48:21.543Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0b/ce0434fb40c5b24b368fe81b17074d2840748b4952256bab451b72290a49/jiter-0.12.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:fd990541982a24281d12b67a335e44f117e4c6cbad3c3b75c7dea68bf4ce3a67", size = 519845, upload-time = "2025-11-09T20:48:22.964Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a3/7a7a4488ba052767846b9c916d208b3ed114e3eb670ee984e4c565b9cf0d/jiter-0.12.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b111b0e9152fa7df870ecaebb0bd30240d9f7fff1f2003bcb4ed0f519941820b", size = 510701, upload-time = "2025-11-09T20:48:24.483Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/16/052ffbf9d0467b70af24e30f91e0579e13ded0c17bb4a8eb2aed3cb60131/jiter-0.12.0-cp314-cp314-win32.whl", hash = "sha256:a78befb9cc0a45b5a5a0d537b06f8544c2ebb60d19d02c41ff15da28a9e22d42", size = 205029, upload-time = "2025-11-09T20:48:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/18/3cf1f3f0ccc789f76b9a754bdb7a6977e5d1d671ee97a9e14f7eb728d80e/jiter-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:e1fe01c082f6aafbe5c8faf0ff074f38dfb911d53f07ec333ca03f8f6226debf", size = 204960, upload-time = "2025-11-09T20:48:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/02/68/736821e52ecfdeeb0f024b8ab01b5a229f6b9293bbdb444c27efade50b0f/jiter-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:d72f3b5a432a4c546ea4bedc84cce0c3404874f1d1676260b9c7f048a9855451", size = 185529, upload-time = "2025-11-09T20:48:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/30/61/12ed8ee7a643cce29ac97c2281f9ce3956eb76b037e88d290f4ed0d41480/jiter-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e6ded41aeba3603f9728ed2b6196e4df875348ab97b28fc8afff115ed42ba7a7", size = 318974, upload-time = "2025-11-09T20:48:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c6/f3041ede6d0ed5e0e79ff0de4c8f14f401bbf196f2ef3971cdbe5fd08d1d/jiter-0.12.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a947920902420a6ada6ad51892082521978e9dd44a802663b001436e4b771684", size = 345932, upload-time = "2025-11-09T20:48:32.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/4d94835889edd01ad0e2dbfc05f7bdfaed46292e7b504a6ac7839aa00edb/jiter-0.12.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:add5e227e0554d3a52cf390a7635edaffdf4f8fce4fdbcef3cc2055bb396a30c", size = 367243, upload-time = "2025-11-09T20:48:34.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/76/0051b0ac2816253a99d27baf3dda198663aff882fa6ea7deeb94046da24e/jiter-0.12.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f9b1cda8fcb736250d7e8711d4580ebf004a46771432be0ae4796944b5dfa5d", size = 479315, upload-time = "2025-11-09T20:48:35.507Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/83f793acd68e5cb24e483f44f482a1a15601848b9b6f199dacb970098f77/jiter-0.12.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:deeb12a2223fe0135c7ff1356a143d57f95bbf1f4a66584f1fc74df21d86b993", size = 380714, upload-time = "2025-11-09T20:48:40.014Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/4808a88338ad2c228b1126b93fcd8ba145e919e886fe910d578230dabe3b/jiter-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c596cc0f4cb574877550ce4ecd51f8037469146addd676d7c1a30ebe6391923f", size = 365168, upload-time = "2025-11-09T20:48:41.462Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d4/04619a9e8095b42aef436b5aeb4c0282b4ff1b27d1db1508df9f5dc82750/jiter-0.12.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ab4c823b216a4aeab3fdbf579c5843165756bd9ad87cc6b1c65919c4715f783", size = 387893, upload-time = "2025-11-09T20:48:42.921Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ea/d3c7e62e4546fdc39197fa4a4315a563a89b95b6d54c0d25373842a59cbe/jiter-0.12.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e427eee51149edf962203ff8db75a7514ab89be5cb623fb9cea1f20b54f1107b", size = 520828, upload-time = "2025-11-09T20:48:44.278Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0b/c6d3562a03fd767e31cb119d9041ea7958c3c80cb3d753eafb19b3b18349/jiter-0.12.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:edb868841f84c111255ba5e80339d386d937ec1fdce419518ce1bd9370fac5b6", size = 511009, upload-time = "2025-11-09T20:48:45.726Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/51/2cb4468b3448a8385ebcd15059d325c9ce67df4e2758d133ab9442b19834/jiter-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8bbcfe2791dfdb7c5e48baf646d37a6a3dcb5a97a032017741dea9f817dca183", size = 205110, upload-time = "2025-11-09T20:48:47.033Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c5/ae5ec83dec9c2d1af805fd5fe8f74ebded9c8670c5210ec7820ce0dbeb1e/jiter-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2fa940963bf02e1d8226027ef461e36af472dea85d36054ff835aeed944dd873", size = 205223, upload-time = "2025-11-09T20:48:49.076Z" },
+    { url = "https://files.pythonhosted.org/packages/97/9a/3c5391907277f0e55195550cf3fa8e293ae9ee0c00fb402fec1e38c0c82f/jiter-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:506c9708dd29b27288f9f8f1140c3cb0e3d8ddb045956d7757b1fa0e0f39a473", size = 185564, upload-time = "2025-11-09T20:48:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f5/12efb8ada5f5c9edc1d4555fe383c1fb2eac05ac5859258a72d61981d999/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e8547883d7b96ef2e5fe22b88f8a4c8725a56e7f4abafff20fd5272d634c7ecb", size = 309974, upload-time = "2025-11-09T20:49:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
 ]
 
 [[package]]
@@ -988,6 +1093,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1116,6 +1234,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/67/9a/0a7acb748b86e2922982366d780ca4b16c33f7246fa5860d26005c97e4f3/smart_open-7.5.0.tar.gz", hash = "sha256:f394b143851d8091011832ac8113ea4aba6b92e6c35f6e677ddaaccb169d7cb9", size = 53920, upload-time = "2025-11-08T21:38:40.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/95/bc978be7ea0babf2fb48a414b6afaad414c6a9e8b1eafc5b8a53c030381a/smart_open-7.5.0-py3-none-any.whl", hash = "sha256:87e695c5148bbb988f15cec00971602765874163be85acb1c9fb8abc012e6599", size = 63940, upload-time = "2025-11-08T21:38:39.024Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -1356,10 +1483,12 @@ name = "vocab"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "ebooklib" },
     { name = "httpx" },
     { name = "lxml" },
+    { name = "pydantic" },
     { name = "spacy" },
 ]
 
@@ -1368,16 +1497,19 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.77.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "ebooklib", specifier = ">=0.20" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=6.0.2" },
+    { name = "pydantic", specifier = ">=2.12.5" },
     { name = "spacy", specifier = ">=3.8.11" },
 ]
 
@@ -1386,6 +1518,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.14" },
 ]


### PR DESCRIPTION
- Add SenseAssignment dataclass for mapping examples to senses
- Implement needs_disambiguation() to check if LLM is needed
- Implement assign_single_sense() for trivial cases
- Implement disambiguate_senses() with Anthropic Claude integration
- Add anthropic, pydantic dependencies
- Add pytest-asyncio for async test support
- Parse LLM tool-use responses into domain objects
- Log and skip unassignable examples

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
