### PR TITLE
feat(anki): implement Anki deck export (Phase 4)

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -863,16 +863,16 @@ asyncio.run(main())
 
 ### Acceptance Criteria
 
-- [ ] `AnkiDeckBuilder` is a context manager
-- [ ] `.add()` accepts `SenseAssignment` and queues a card
-- [ ] On context exit, writes valid `.apkg` file
-- [ ] Card front shows English translation
-- [ ] Card back shows word, IPA, examples, forms
-- [ ] Examples are formatted with guillemets and word highlighted
-- [ ] CSS styling applied correctly
-- [ ] `uv run ruff check .` passes
-- [ ] `uv run mypy .` passes
-- [ ] `uv run pytest --cov=vocab --cov-fail-under=90` passes
+- [x] `AnkiDeckBuilder` is a context manager
+- [x] `.add()` accepts `SenseAssignment` and queues a card
+- [x] On context exit, writes valid `.apkg` file
+- [x] Card front shows English translation
+- [x] Card back shows word, IPA, examples, forms
+- [x] Examples are formatted with guillemets and word highlighted
+- [x] CSS styling applied correctly
+- [x] `uv run ruff check .` passes
+- [x] `uv run mypy .` passes
+- [x] `uv run pytest --cov=vocab --cov-fail-under=90` passes
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anthropic>=0.77.0",
     "beautifulsoup4>=4.14.3",
     "ebooklib>=0.20",
+    "genanki>=0.13.1",
     "httpx>=0.28.1",
     "lxml>=6.0.2",
     "pydantic>=2.12.5",
@@ -98,6 +99,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["spacy", "spacy.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["genanki", "genanki.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/vocab/__init__.py
+++ b/src/vocab/__init__.py
@@ -1,5 +1,6 @@
 """Vocabulary extraction from ePub files."""
 
+from vocab.anki import AnkiDeckBuilder
 from vocab.dictionary import (
     SPACY_TO_KAIKKI,
     Dictionary,
@@ -30,6 +31,7 @@ from vocab.tokens import extract_tokens
 from vocab.vocabulary import build_vocabulary
 
 __all__ = [
+    "AnkiDeckBuilder",
     "Chapter",
     "Dictionary",
     "DictionaryEntry",

--- a/src/vocab/anki.py
+++ b/src/vocab/anki.py
@@ -1,0 +1,240 @@
+"""Anki deck generation from sense assignments."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+from types import TracebackType
+
+import genanki
+
+from vocab.pipeline import SenseAssignment
+
+# CSS styling for cards
+CARD_CSS = """\
+.card {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  line-height: 1.5;
+}
+.front {
+  font-size: 24px;
+  text-align: center;
+}
+.back {
+  text-align: center;
+}
+.word {
+  font-size: 28px;
+  font-weight: bold;
+  text-align: center;
+}
+.ipa {
+  font-family: "Doulos SIL", "Noto Sans", serif;
+  color: #555;
+  text-align: center;
+  margin: 10px 0;
+}
+.examples {
+  font-style: italic;
+  margin: 15px 0;
+  text-align: left;
+}
+.examples .example {
+  margin: 8px 0;
+}
+.forms {
+  font-size: 14px;
+  color: #888;
+  text-align: center;
+}
+"""
+
+# Card template
+FRONT_TEMPLATE = """\
+<div class="front">{{Translation}}</div>
+"""
+
+BACK_TEMPLATE = """\
+<div class="back">
+  <div class="word">{{Word}}</div>
+  {{#IPA}}<div class="ipa">{{IPA}}</div>{{/IPA}}
+  {{#Examples}}<div class="examples">{{Examples}}</div>{{/Examples}}
+  {{#Forms}}<div class="forms">Forms: {{Forms}}</div>{{/Forms}}
+</div>
+"""
+
+
+# Namespace UUID for generating deterministic IDs
+_VOCAB_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+
+def _generate_model_id(deck_name: str, language: str) -> int:
+    """Generate a deterministic model ID based on deck properties.
+
+    Uses UUIDv5 to ensure the same deck name and language always
+    produce the same model ID, preventing duplicate models in Anki.
+    """
+    name = f"{deck_name}:{language}:model"
+    uid = uuid.uuid5(_VOCAB_NAMESPACE, name)
+    return int(uid) >> 96  # Use top 32 bits
+
+
+def _generate_deck_id(deck_name: str, language: str) -> int:
+    """Generate a deterministic deck ID based on deck properties.
+
+    Uses UUIDv5 to ensure the same deck name and language always
+    produce the same deck ID, preventing duplicate decks in Anki.
+    """
+    name = f"{deck_name}:{language}:deck"
+    uid = uuid.uuid5(_VOCAB_NAMESPACE, name)
+    return int(uid) >> 96  # Use top 32 bits
+
+
+def _format_examples(assignment: SenseAssignment) -> str:
+    """Format example sentences with guillemets and highlighted word.
+
+    Args:
+        assignment: SenseAssignment containing examples.
+
+    Returns:
+        HTML-formatted examples string.
+    """
+    examples_html: list[str] = []
+    word = assignment.lemma.lemma
+
+    for idx in assignment.examples:
+        sentence = assignment.lemma.examples[idx].sentence
+        # Highlight the word in the sentence (case-insensitive)
+        highlighted = _highlight_word(sentence, word)
+        examples_html.append(f'<div class="example">« {highlighted} »</div>')
+
+    return "\n".join(examples_html)
+
+
+def _highlight_word(sentence: str, word: str) -> str:
+    """Highlight occurrences of a word in a sentence.
+
+    Args:
+        sentence: The sentence text.
+        word: The word to highlight.
+
+    Returns:
+        Sentence with word wrapped in <b> tags.
+    """
+    return re.sub(
+        re.escape(word),
+        lambda m: f"<b>{m.group()}</b>",
+        sentence,
+        flags=re.IGNORECASE,
+    )
+
+
+def _format_forms(assignment: SenseAssignment) -> str:
+    """Format the forms used in examples.
+
+    Args:
+        assignment: SenseAssignment containing lemma with forms.
+
+    Returns:
+        Comma-separated list of forms.
+    """
+    return ", ".join(sorted(assignment.lemma.forms.keys()))
+
+
+class AnkiDeckBuilder:
+    """Context manager for building an Anki deck.
+
+    Usage:
+        with AnkiDeckBuilder(path, deck_name, language) as deck:
+            deck.add(sense_assignment)
+        # Deck is written on context exit
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        deck_name: str,
+        source_language: str,
+    ) -> None:
+        """Initialize the deck builder.
+
+        Args:
+            path: Output path for the .apkg file.
+            deck_name: Name for the Anki deck.
+            source_language: Source language code (e.g., "fr").
+        """
+        self._path = path
+        self._deck_name = deck_name
+        self._source_language = source_language
+
+        # Create model and deck
+        self._model = genanki.Model(
+            _generate_model_id(deck_name, source_language),
+            f"Vocab {source_language}",
+            fields=[
+                {"name": "Translation"},
+                {"name": "Word"},
+                {"name": "IPA"},
+                {"name": "Examples"},
+                {"name": "Forms"},
+            ],
+            templates=[
+                {
+                    "name": "Card 1",
+                    "qfmt": FRONT_TEMPLATE,
+                    "afmt": BACK_TEMPLATE,
+                },
+            ],
+            css=CARD_CSS,
+        )
+
+        self._deck = genanki.Deck(_generate_deck_id(deck_name, source_language), deck_name)
+        self._cards_added = 0
+
+    def add(self, entry: SenseAssignment) -> None:
+        """Add a card for this sense assignment.
+
+        Creates a card with:
+        - Front: English translation (from sense)
+        - Back: Word, IPA, examples, forms
+
+        Args:
+            entry: SenseAssignment to create a card from.
+        """
+        sense = entry.word.senses[entry.sense]
+
+        # Build field values
+        translation = sense.translation
+        word = entry.word.word
+        ipa = entry.word.ipa or ""
+        examples = _format_examples(entry)
+        forms = _format_forms(entry)
+
+        note = genanki.Note(
+            model=self._model,
+            fields=[translation, word, ipa, examples, forms],
+        )
+        self._deck.add_note(note)
+        self._cards_added += 1
+
+    @property
+    def cards_added(self) -> int:
+        """Return the number of cards added to the deck."""
+        return self._cards_added
+
+    def __enter__(self) -> AnkiDeckBuilder:
+        """Enter context."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Write the .apkg file and clean up."""
+        if exc_type is None:
+            # Only write if no exception occurred
+            package = genanki.Package(self._deck)
+            package.write_to_file(str(self._path))

--- a/tests/test_anki.py
+++ b/tests/test_anki.py
@@ -1,0 +1,351 @@
+"""Tests for the anki module."""
+
+import zipfile
+from pathlib import Path
+
+from vocab.anki import (
+    AnkiDeckBuilder,
+    _format_examples,
+    _format_forms,
+    _generate_deck_id,
+    _generate_model_id,
+    _highlight_word,
+)
+from vocab.dictionary import DictionaryEntry, DictionarySense
+from vocab.models import Example, LemmaEntry, SentenceLocation
+from vocab.pipeline import SenseAssignment
+
+
+def make_sense_assignment(
+    word: str = "chien",
+    pos: str = "noun",
+    translation: str = "dog",
+    ipa: str = "/ʃjɛ̃/",
+    examples: list[str] | None = None,
+    example_indices: list[int] | None = None,
+) -> SenseAssignment:
+    """Create a SenseAssignment for testing."""
+    if examples is None:
+        examples = ["Le chien aboie."]
+    if example_indices is None:
+        example_indices = list(range(len(examples)))
+
+    lemma = LemmaEntry(
+        lemma=word,
+        pos=pos.upper(),
+        frequency=len(examples),
+        forms={word: len(examples)},
+        examples=[
+            Example(
+                sentence=s,
+                location=SentenceLocation(
+                    chapter_index=0,
+                    chapter_title="Chapter 1",
+                    sentence_index=i,
+                ),
+            )
+            for i, s in enumerate(examples)
+        ],
+    )
+
+    dict_entry = DictionaryEntry(
+        word=word,
+        pos=pos,
+        ipa=ipa,
+        etymology=None,
+        senses=[
+            DictionarySense(
+                id=f"{word}-{pos}-1",
+                translation=translation,
+                example=None,
+            )
+        ],
+    )
+
+    return SenseAssignment(
+        lemma=lemma,
+        examples=example_indices,
+        word=dict_entry,
+        sense=0,
+    )
+
+
+class TestDeterministicIds:
+    """Tests for deterministic ID generation."""
+
+    def test_model_id_is_deterministic(self) -> None:
+        """Test that model ID is the same for same inputs."""
+        id1 = _generate_model_id("Test Deck", "fr")
+        id2 = _generate_model_id("Test Deck", "fr")
+        assert id1 == id2
+
+    def test_deck_id_is_deterministic(self) -> None:
+        """Test that deck ID is the same for same inputs."""
+        id1 = _generate_deck_id("Test Deck", "fr")
+        id2 = _generate_deck_id("Test Deck", "fr")
+        assert id1 == id2
+
+    def test_different_deck_names_produce_different_ids(self) -> None:
+        """Test that different deck names produce different IDs."""
+        id1 = _generate_model_id("Deck A", "fr")
+        id2 = _generate_model_id("Deck B", "fr")
+        assert id1 != id2
+
+    def test_different_languages_produce_different_ids(self) -> None:
+        """Test that different languages produce different IDs."""
+        id1 = _generate_model_id("Test Deck", "fr")
+        id2 = _generate_model_id("Test Deck", "es")
+        assert id1 != id2
+
+    def test_model_and_deck_ids_are_different(self) -> None:
+        """Test that model and deck IDs differ for same inputs."""
+        model_id = _generate_model_id("Test Deck", "fr")
+        deck_id = _generate_deck_id("Test Deck", "fr")
+        assert model_id != deck_id
+
+
+class TestHighlightWord:
+    """Tests for _highlight_word function."""
+
+    def test_highlights_exact_match(self) -> None:
+        """Test highlighting exact word match."""
+        result = _highlight_word("Le chien aboie.", "chien")
+        assert result == "Le <b>chien</b> aboie."
+
+    def test_case_insensitive(self) -> None:
+        """Test case-insensitive highlighting."""
+        result = _highlight_word("Le Chien aboie.", "chien")
+        assert result == "Le <b>Chien</b> aboie."
+
+    def test_multiple_occurrences(self) -> None:
+        """Test highlighting multiple occurrences."""
+        result = _highlight_word("Un chien voit un autre chien.", "chien")
+        assert result == "Un <b>chien</b> voit un autre <b>chien</b>."
+
+    def test_no_match(self) -> None:
+        """Test when word is not in sentence."""
+        result = _highlight_word("Le chat miaule.", "chien")
+        assert result == "Le chat miaule."
+
+
+class TestFormatExamples:
+    """Tests for _format_examples function."""
+
+    def test_formats_single_example(self) -> None:
+        """Test formatting a single example."""
+        assignment = make_sense_assignment(examples=["Le chien aboie."])
+        result = _format_examples(assignment)
+        assert "« Le <b>chien</b> aboie. »" in result
+        assert 'class="example"' in result
+
+    def test_formats_multiple_examples(self) -> None:
+        """Test formatting multiple examples."""
+        assignment = make_sense_assignment(
+            examples=["Le chien aboie.", "Mon chien dort."],
+            example_indices=[0, 1],
+        )
+        result = _format_examples(assignment)
+        assert "« Le <b>chien</b> aboie. »" in result
+        assert "« Mon <b>chien</b> dort. »" in result
+
+    def test_uses_only_specified_indices(self) -> None:
+        """Test that only specified example indices are used."""
+        assignment = make_sense_assignment(
+            examples=["First.", "Second.", "Third."],
+            example_indices=[0, 2],  # Skip index 1
+            word="test",
+        )
+        result = _format_examples(assignment)
+        assert "First" in result
+        assert "Second" not in result
+        assert "Third" in result
+
+    def test_empty_examples_returns_empty_string(self) -> None:
+        """Test that empty examples list returns empty string."""
+        assignment = make_sense_assignment(
+            examples=["Unused sentence."],
+            example_indices=[],  # No examples selected
+        )
+        result = _format_examples(assignment)
+        assert result == ""
+
+
+class TestFormatForms:
+    """Tests for _format_forms function."""
+
+    def test_formats_single_form(self) -> None:
+        """Test formatting a single form."""
+        assignment = make_sense_assignment()
+        result = _format_forms(assignment)
+        assert result == "chien"
+
+    def test_formats_multiple_forms_sorted(self) -> None:
+        """Test formatting multiple forms in sorted order."""
+        lemma = LemmaEntry(
+            lemma="manger",
+            pos="VERB",
+            frequency=3,
+            forms={"mange": 1, "mangeons": 1, "manger": 1},
+            examples=[
+                Example(
+                    sentence="Test",
+                    location=SentenceLocation(
+                        chapter_index=0, chapter_title=None, sentence_index=0
+                    ),
+                )
+            ],
+        )
+        dict_entry = DictionaryEntry(
+            word="manger",
+            pos="verb",
+            ipa="/mɑ̃.ʒe/",
+            etymology=None,
+            senses=[DictionarySense(id="1", translation="to eat", example=None)],
+        )
+        assignment = SenseAssignment(lemma=lemma, examples=[0], word=dict_entry, sense=0)
+
+        result = _format_forms(assignment)
+        assert result == "mange, mangeons, manger"
+
+
+class TestAnkiDeckBuilder:
+    """Tests for AnkiDeckBuilder class."""
+
+    def test_is_context_manager(self, tmp_path: Path) -> None:
+        """Test that AnkiDeckBuilder is a context manager."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            assert deck is not None
+
+    def test_writes_apkg_on_exit(self, tmp_path: Path) -> None:
+        """Test that .apkg file is written on context exit."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment())
+
+        assert output_path.exists()
+
+    def test_apkg_is_valid_zip(self, tmp_path: Path) -> None:
+        """Test that .apkg file is a valid zip archive."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment())
+
+        assert zipfile.is_zipfile(output_path)
+
+    def test_apkg_contains_expected_files(self, tmp_path: Path) -> None:
+        """Test that .apkg contains expected Anki files."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment())
+
+        with zipfile.ZipFile(output_path) as zf:
+            names = zf.namelist()
+            # Anki packages should contain these files
+            assert any("collection.anki2" in n for n in names)
+
+    def test_add_increments_cards_count(self, tmp_path: Path) -> None:
+        """Test that adding cards increments the count."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            assert deck.cards_added == 0
+            deck.add(make_sense_assignment())
+            assert deck.cards_added == 1
+            deck.add(make_sense_assignment(word="chat", translation="cat"))
+            assert deck.cards_added == 2
+
+    def test_card_has_translation_on_front(self, tmp_path: Path) -> None:
+        """Test that card front contains the translation."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment(translation="dog"))
+            # Check that the model has the expected template
+            assert "{{Translation}}" in deck._model.templates[0]["qfmt"]
+
+    def test_card_has_word_on_back(self, tmp_path: Path) -> None:
+        """Test that card back contains the word."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment(word="chien"))
+            # Check that the model has the expected template
+            assert "{{Word}}" in deck._model.templates[0]["afmt"]
+
+    def test_card_has_ipa_on_back(self, tmp_path: Path) -> None:
+        """Test that card back contains IPA."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment(ipa="/ʃjɛ̃/"))
+            assert "{{IPA}}" in deck._model.templates[0]["afmt"]
+
+    def test_handles_missing_ipa(self, tmp_path: Path) -> None:
+        """Test that missing IPA is handled gracefully."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            assignment = make_sense_assignment(ipa=None)  # type: ignore[arg-type]
+            assignment.word = DictionaryEntry(
+                word="test",
+                pos="noun",
+                ipa=None,
+                etymology=None,
+                senses=[DictionarySense(id="1", translation="test", example=None)],
+            )
+            deck.add(assignment)
+        assert output_path.exists()
+
+    def test_does_not_write_on_exception(self, tmp_path: Path) -> None:
+        """Test that file is not written if an exception occurs."""
+        output_path = tmp_path / "test.apkg"
+        try:
+            with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+                deck.add(make_sense_assignment())
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        assert not output_path.exists()
+
+    def test_handles_empty_examples(self, tmp_path: Path) -> None:
+        """Test that cards with no examples are created correctly."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            assignment = make_sense_assignment(
+                examples=["Unused."],
+                example_indices=[],  # No examples
+            )
+            deck.add(assignment)
+
+        assert output_path.exists()
+        assert deck.cards_added == 1
+
+    def test_css_styling_applied(self, tmp_path: Path) -> None:
+        """Test that CSS styling is applied to the model."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            assert ".front" in deck._model.css
+            assert ".word" in deck._model.css
+            assert ".ipa" in deck._model.css
+            assert ".examples" in deck._model.css
+            assert ".forms" in deck._model.css
+
+
+class TestAnkiDeckBuilderMultipleCards:
+    """Tests for adding multiple cards to a deck."""
+
+    def test_adds_multiple_cards(self, tmp_path: Path) -> None:
+        """Test adding multiple cards to a deck."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment(word="chien", translation="dog"))
+            deck.add(make_sense_assignment(word="chat", translation="cat"))
+            deck.add(make_sense_assignment(word="oiseau", translation="bird"))
+
+        assert deck.cards_added == 3
+
+    def test_different_senses_same_word(self, tmp_path: Path) -> None:
+        """Test adding cards for different senses of the same word."""
+        output_path = tmp_path / "test.apkg"
+        with AnkiDeckBuilder(output_path, "Test Deck", "fr") as deck:
+            deck.add(make_sense_assignment(word="faux", translation="forgery"))
+            deck.add(make_sense_assignment(word="faux", translation="scythe"))
+
+        assert deck.cards_added == 2

--- a/uv.lock
+++ b/uv.lock
@@ -89,6 +89,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cached-property"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/4b/3d870836119dbe9a5e3c9a61af8cc1a8b69d75aea564572e385882d5aefb/cached_property-2.0.1.tar.gz", hash = "sha256:484d617105e3ee0e4f1f58725e72a8ef9e93deee462222dbd51cd91230897641", size = 10574, upload-time = "2024-10-25T15:43:55.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/0e/7d8225aab3bc1a0f5811f8e1b557aa034ac04bdf641925b30d3caf586b28/cached_property-2.0.1-py3-none-any.whl", hash = "sha256:f617d70ab1100b7bcf6e42228f9ddcb78c676ffa167278d9f730d1c2fba69ccb", size = 7428, upload-time = "2024-10-25T15:43:54.711Z" },
+]
+
+[[package]]
 name = "catalogue"
 version = "2.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -170,6 +179,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "chevron"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/1f/ca74b65b19798895d63a6e92874162f44233467c9e7c1ed8afd19016ebe9/chevron-0.14.0.tar.gz", hash = "sha256:87613aafdf6d77b6a90ff073165a61ae5086e21ad49057aa0e53681601800ebf", size = 11440, upload-time = "2021-01-02T22:47:59.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/93/342cc62a70ab727e093ed98e02a725d85b746345f05d2b5e5034649f4ec8/chevron-0.14.0-py3-none-any.whl", hash = "sha256:fbf996a709f8da2e745ef763f482ce2d311aa817d287593a5b990d6d6e4f0443", size = 11595, upload-time = "2021-01-02T22:47:57.847Z" },
 ]
 
 [[package]]
@@ -384,6 +402,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "frozendict"
+version = "2.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/b2/2a3d1374b7780999d3184e171e25439a8358c47b481f68be883c14086b4c/frozendict-2.4.7.tar.gz", hash = "sha256:e478fb2a1391a56c8a6e10cc97c4a9002b410ecd1ac28c18d780661762e271bd", size = 317082, upload-time = "2025-11-11T22:40:14.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl", hash = "sha256:972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550", size = 16264, upload-time = "2025-11-11T22:40:12.836Z" },
+]
+
+[[package]]
+name = "genanki"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cached-property" },
+    { name = "chevron" },
+    { name = "frozendict" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/07/4459ffd44e8abfd52743f915ab6c0d4c227ee9da3f7f649c930146a93438/genanki-0.13.1.tar.gz", hash = "sha256:84d090423a8879520465bfe9784083edacb8d35e2ba511fa5a1bdef01d8f71ed", size = 23340, upload-time = "2023-11-12T18:25:16.802Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/7e/6c74ea7aaf2a36fd7df281267fade72e1f06ed1e44315bd77af2c6f82800/genanki-0.13.1-py3-none-any.whl", hash = "sha256:65b59434008588a1213b940474d1aca8cca83243af6fc0e26200b560efe4d9e3", size = 16177, upload-time = "2023-11-12T18:25:15.201Z" },
 ]
 
 [[package]]
@@ -1486,6 +1528,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "ebooklib" },
+    { name = "genanki" },
     { name = "httpx" },
     { name = "lxml" },
     { name = "pydantic" },
@@ -1507,6 +1550,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.77.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "ebooklib", specifier = ">=0.20" },
+    { name = "genanki", specifier = ">=0.13.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "pydantic", specifier = ">=2.12.5" },


### PR DESCRIPTION
- Add AnkiDeckBuilder context manager for .apkg generation
- Create card template with front (translation) and back (word, IPA, examples, forms)
- Apply CSS styling for clean card appearance
- Format examples with guillemets « » and highlighted word
- Add genanki dependency
- Add comprehensive tests for Anki export

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
