### PR TITLE
refactor(pipeline): replace generate_enriched_lemmas with enrich_lemma

### DIFF
--- a/src/vocab/__init__.py
+++ b/src/vocab/__init__.py
@@ -23,7 +23,7 @@ from vocab.pipeline import (
     SenseAssignment,
     assign_single_sense,
     disambiguate_senses,
-    generate_enriched_lemmas,
+    enrich_lemma,
     needs_disambiguation,
 )
 from vocab.sentences import SpacyModelNotFoundError, extract_sentences
@@ -50,9 +50,9 @@ __all__ = [
     "assign_single_sense",
     "build_vocabulary",
     "disambiguate_senses",
+    "enrich_lemma",
     "extract_chapters",
     "extract_sentences",
     "extract_tokens",
-    "generate_enriched_lemmas",
     "needs_disambiguation",
 ]

--- a/src/vocab/models.py
+++ b/src/vocab/models.py
@@ -1,5 +1,6 @@
 """Data models for vocabulary extraction."""
 
+from collections.abc import Iterator
 from dataclasses import asdict, dataclass
 from typing import Any
 
@@ -111,6 +112,15 @@ class Vocabulary:
 
     entries: dict[str, dict[str, LemmaEntry]]
     language: str
+
+    def __iter__(self) -> Iterator[LemmaEntry]:
+        """Iterate over all LemmaEntry objects in the vocabulary.
+
+        Yields:
+            Each LemmaEntry in the vocabulary.
+        """
+        for pos_dict in self.entries.values():
+            yield from pos_dict.values()
 
     def to_dict(self) -> dict[str, Any]:
         """Export vocabulary as a JSON-serializable dictionary.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from vocab.dictionary import DictionaryEntry, DictionarySense
-from vocab.models import Example, LemmaEntry, SentenceLocation, Vocabulary
+from vocab.models import Example, LemmaEntry, SentenceLocation
 from vocab.pipeline import (
     DisambiguationResponse,
     EnrichedLemma,
@@ -15,7 +15,7 @@ from vocab.pipeline import (
     _parse_llm_response,
     assign_single_sense,
     disambiguate_senses,
-    generate_enriched_lemmas,
+    enrich_lemma,
     needs_disambiguation,
 )
 
@@ -97,173 +97,81 @@ class TestEnrichedLemma:
             EnrichedLemma(lemma=lemma, words=words)
 
 
-class TestGenerateEnrichedLemmas:
-    """Tests for generate_enriched_lemmas function."""
+class TestEnrichLemma:
+    """Tests for enrich_lemma function."""
 
-    def test_yields_enriched_lemmas_for_matches(self) -> None:
-        """Test that matching lemmas are yielded."""
-        vocab = Vocabulary(
-            entries={
-                "chien": {"NOUN": make_lemma_entry("chien", "NOUN")},
-            },
-            language="fr",
-        )
+    def test_returns_enriched_lemma_for_match(self) -> None:
+        """Test that matching lemma returns EnrichedLemma."""
+        lemma = make_lemma_entry("chien", "NOUN")
 
         mock_dict = MagicMock()
         mock_dict.lookup.return_value = [make_dictionary_entry("chien", "noun", "dog")]
 
-        results = list(generate_enriched_lemmas(vocab, mock_dict))
+        result = enrich_lemma(lemma, mock_dict)
 
-        assert len(results) == 1
-        assert results[0].lemma.lemma == "chien"
-        assert results[0].words[0].senses[0].translation == "dog"
+        assert result is not None
+        assert result.lemma.lemma == "chien"
+        assert result.words[0].senses[0].translation == "dog"
 
-    def test_skips_lemmas_without_matches(self) -> None:
-        """Test that lemmas without dictionary matches are skipped."""
-        vocab = Vocabulary(
-            entries={
-                "xyznonexistent": {"NOUN": make_lemma_entry("xyznonexistent", "NOUN")},
-            },
-            language="fr",
-        )
+    def test_returns_none_without_match(self) -> None:
+        """Test that lemma without dictionary match returns None."""
+        lemma = make_lemma_entry("xyznonexistent", "NOUN")
 
         mock_dict = MagicMock()
-        mock_dict.lookup.return_value = []  # No matches
+        mock_dict.lookup.return_value = []
 
-        results = list(generate_enriched_lemmas(vocab, mock_dict))
+        result = enrich_lemma(lemma, mock_dict)
 
-        assert len(results) == 0
+        assert result is None
 
     def test_uses_spacy_to_kaikki_mapping(self) -> None:
         """Test that POS is mapped from spaCy to kaikki format."""
-        vocab = Vocabulary(
-            entries={
-                "manger": {"VERB": make_lemma_entry("manger", "VERB")},
-            },
-            language="fr",
-        )
+        lemma = make_lemma_entry("manger", "VERB")
 
         mock_dict = MagicMock()
         mock_dict.lookup.return_value = [make_dictionary_entry("manger", "verb", "to eat")]
 
-        list(generate_enriched_lemmas(vocab, mock_dict))
+        enrich_lemma(lemma, mock_dict)
 
-        # Should have called lookup with kaikki POS ["verb"]
         mock_dict.lookup.assert_called_once_with("manger", pos=["verb"])
 
     def test_handles_unmapped_pos(self) -> None:
         """Test that unmapped POS tags pass None to lookup."""
-        vocab = Vocabulary(
-            entries={
-                "test": {"UNKNOWN_POS": make_lemma_entry("test", "UNKNOWN_POS")},
-            },
-            language="fr",
-        )
+        lemma = make_lemma_entry("test", "UNKNOWN_POS")
 
         mock_dict = MagicMock()
         mock_dict.lookup.return_value = [make_dictionary_entry("test", "noun")]
 
-        list(generate_enriched_lemmas(vocab, mock_dict))
+        enrich_lemma(lemma, mock_dict)
 
-        # Should have called lookup with pos=None for unmapped POS
         mock_dict.lookup.assert_called_once_with("test", pos=None)
-
-    def test_processes_multiple_lemmas(self) -> None:
-        """Test processing vocabulary with multiple lemmas."""
-        vocab = Vocabulary(
-            entries={
-                "chien": {"NOUN": make_lemma_entry("chien", "NOUN")},
-                "manger": {"VERB": make_lemma_entry("manger", "VERB")},
-                "beau": {"ADJ": make_lemma_entry("beau", "ADJ")},
-            },
-            language="fr",
-        )
-
-        mock_dict = MagicMock()
-        mock_dict.lookup.side_effect = [
-            [make_dictionary_entry("chien", "noun", "dog")],
-            [make_dictionary_entry("manger", "verb", "to eat")],
-            [],  # beau has no match
-        ]
-
-        results = list(generate_enriched_lemmas(vocab, mock_dict))
-
-        assert len(results) == 2
-        lemmas = {r.lemma.lemma for r in results}
-        assert lemmas == {"chien", "manger"}
-
-    def test_processes_same_lemma_different_pos(self) -> None:
-        """Test processing same lemma with different POS tags."""
-        vocab = Vocabulary(
-            entries={
-                "faux": {
-                    "NOUN": make_lemma_entry("faux", "NOUN"),
-                    "ADJ": make_lemma_entry("faux", "ADJ"),
-                },
-            },
-            language="fr",
-        )
-
-        mock_dict = MagicMock()
-        mock_dict.lookup.side_effect = [
-            [make_dictionary_entry("faux", "noun", "forgery")],
-            [make_dictionary_entry("faux", "adj", "false")],
-        ]
-
-        results = list(generate_enriched_lemmas(vocab, mock_dict))
-
-        assert len(results) == 2
-        pos_set = {r.lemma.pos for r in results}
-        assert pos_set == {"NOUN", "ADJ"}
 
     def test_returns_multiple_dictionary_entries(self) -> None:
         """Test that multiple dictionary entries are preserved."""
-        vocab = Vocabulary(
-            entries={
-                "faux": {"NOUN": make_lemma_entry("faux", "NOUN")},
-            },
-            language="fr",
-        )
+        lemma = make_lemma_entry("faux", "NOUN")
 
         mock_dict = MagicMock()
-        # Two different etymologies for "faux" as noun
         mock_dict.lookup.return_value = [
             make_dictionary_entry("faux", "noun", "forgery"),
             make_dictionary_entry("faux", "noun", "scythe"),
         ]
 
-        results = list(generate_enriched_lemmas(vocab, mock_dict))
+        result = enrich_lemma(lemma, mock_dict)
 
-        assert len(results) == 1
-        assert len(results[0].words) == 2
-        translations = {w.senses[0].translation for w in results[0].words}
+        assert result is not None
+        assert len(result.words) == 2
+        translations = {w.senses[0].translation for w in result.words}
         assert translations == {"forgery", "scythe"}
-
-    def test_empty_vocabulary_yields_nothing(self) -> None:
-        """Test that empty vocabulary yields no results."""
-        vocab = Vocabulary(entries={}, language="fr")
-        mock_dict = MagicMock()
-
-        results = list(generate_enriched_lemmas(vocab, mock_dict))
-
-        assert len(results) == 0
-        mock_dict.lookup.assert_not_called()
 
     def test_adp_maps_to_multiple_pos(self) -> None:
         """Test that ADP maps to prep, prep_phrase, postp."""
-        vocab = Vocabulary(
-            entries={
-                "dans": {"ADP": make_lemma_entry("dans", "ADP")},
-            },
-            language="fr",
-        )
+        lemma = make_lemma_entry("dans", "ADP")
 
         mock_dict = MagicMock()
         mock_dict.lookup.return_value = [make_dictionary_entry("dans", "prep", "in")]
 
-        list(generate_enriched_lemmas(vocab, mock_dict))
+        enrich_lemma(lemma, mock_dict)
 
-        # Should call with all mapped POS tags
         call_args = mock_dict.lookup.call_args
         assert call_args[0][0] == "dans"
         assert set(call_args[1]["pos"]) == {"prep", "prep_phrase", "postp"}

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -503,6 +503,45 @@ class TestDuplicateTokenInSentence:
         assert len(vocab.entries["chat"]["NOUN"].examples) == 1
 
 
+class TestVocabularyIteration:
+    """Tests for Vocabulary iteration support."""
+
+    def test_iterating_yields_all_lemma_entries(self) -> None:
+        """Iterating over Vocabulary should yield all LemmaEntry objects."""
+        entries = {
+            "chat": {
+                "NOUN": LemmaEntry(
+                    lemma="chat", pos="NOUN", frequency=5, forms={"chat": 5}, examples=[]
+                ),
+            },
+            "run": {
+                "VERB": LemmaEntry(
+                    lemma="run", pos="VERB", frequency=3, forms={"run": 2, "runs": 1}, examples=[]
+                ),
+                "NOUN": LemmaEntry(
+                    lemma="run", pos="NOUN", frequency=1, forms={"run": 1}, examples=[]
+                ),
+            },
+        }
+        vocab = Vocabulary(entries=entries, language="en")
+
+        result = list(vocab)
+
+        assert len(result) == 3
+        assert all(isinstance(entry, LemmaEntry) for entry in result)
+        # Check all entries are present (order not guaranteed)
+        lemma_pos_pairs = {(e.lemma, e.pos) for e in result}
+        assert lemma_pos_pairs == {("chat", "NOUN"), ("run", "VERB"), ("run", "NOUN")}
+
+    def test_iterating_empty_vocabulary(self) -> None:
+        """Iterating over empty Vocabulary should yield nothing."""
+        vocab = Vocabulary(entries={}, language="en")
+
+        result = list(vocab)
+
+        assert result == []
+
+
 class TestSkipEmptyPos:
     """Tests for skipping tokens with empty POS."""
 


### PR DESCRIPTION
- Add Vocabulary.__iter__() to iterate over all LemmaEntry objects
- Extract enrich_lemma() as public API for enriching single lemmas
- Remove generate_enriched_lemmas() generator function
- Update __init__.py exports to include enrich_lemma
- Update plan.md examples to use new iteration pattern

The new usage pattern is:
  for lemma_entry in vocab:
      enriched = enrich_lemma(lemma_entry, dictionary)
      if enriched:
          # process enriched lemma

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
