### PR TITLE
feat(anki): add audio pronunciation to flashcards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,7 @@ When fully implemented and code reviewed:
 1. Run final quality checks (ruff, mypy, pytest)
 2. Verify README.md accuracy (features, examples, coverage badge, architecture)
 3. Check plan.md for info to preserve (decisions → docstrings, future work → Issues)
-4. Suggest CHANGELOG.md if project will be versioned; otherwise keep docs minimal
-5. Delete `docs/plan.md` and empty `docs/` directory
+4. Squash all phase commits into a single commit:
+   - Use `git reset --soft <commit-before-first-phase>`
+   - Write a commit message describing the feature as a whole (not individual phases)
+   - The message should explain what the feature does and key implementation details

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ vocab is a Python library that extracts words from ePub files, performs lemmatiz
 - Track word frequencies with original forms and example sentences
 - Dictionary lookups via Wiktionary (kaikki.org) with POS filtering
 - LLM-powered sense disambiguation for polysemous words
-- Export to Anki `.apkg` format with styled flashcards
+- Export to Anki `.apkg` format with styled flashcards and audio pronunciation
 
 ## Installation
 
@@ -179,7 +179,7 @@ async def create_anki_deck():
     vocab = build_vocabulary(Path("book.epub"), "fr", max_examples=3)
     dictionary = Dictionary("fr")
 
-    with AnkiDeckBuilder(
+    async with AnkiDeckBuilder(
         path=Path("vocabulary.apkg"),
         deck_name="French Vocabulary",
         source_language="fr",
@@ -190,15 +190,18 @@ async def create_anki_deck():
                 continue
 
             if not needs_disambiguation(enriched):
-                deck.add(assign_single_sense(enriched))
+                await deck.add(assign_single_sense(enriched))
             else:
                 for assignment in await disambiguate_senses(enriched):
-                    deck.add(assignment)
+                    await deck.add(assignment)
 
     print("Generated: vocabulary.apkg")
 
 asyncio.run(create_anki_deck())
 ```
+
+Cards include audio pronunciation when available from Wiktionary. Audio files are
+cached locally (~/.cache/vocab/media/) to avoid re-downloading.
 
 ## Development
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,142 @@
+# Audio Support for Anki Cards
+
+## Overview
+
+Add audio playback to generated Anki cards by extracting audio URLs from kaikki dictionary data and embedding MP3 files in the `.apkg` package.
+
+## Architecture
+
+### Data Flow
+
+```
+kaikki sounds[] → DictionaryEntry.audio_url → AnkiDeckBuilder.add() → download MP3 → embed in .apkg
+```
+
+### Key Decisions
+
+| Decision | Resolution |
+|----------|------------|
+| Audio format | MP3 (universal Anki support) |
+| Which audio | First `mp3_url` in kaikki `sounds[]` |
+| Filename | `{card_guid}.mp3` |
+| URL streaming | Not viable - must embed files |
+| Download strategy | Async with semaphore-limited concurrency |
+| Concurrency limit | 16 concurrent downloads (configurable) |
+| Caching | `~/.cache/vocab/audio/` to avoid re-downloads |
+| Error handling | Log warning, card works without audio |
+| Replay | Built-in Anki behavior (R or F5 hotkey) |
+
+---
+
+## Phase 1: Data Model
+
+Add audio URL extraction to the dictionary layer.
+
+### Changes
+
+**src/vocab/dictionary.py**
+- Add `audio_url: str | None` field to `DictionaryEntry`
+- Add `_extract_audio_url()` static method that returns first `mp3_url` from `sounds[]`
+- Update `from_kaikki()` to call the new extractor
+
+**tests/test_dictionary.py**
+- Add test for `_extract_audio_url()` with various sound configurations:
+  - Entry with multiple audio files (returns first mp3_url)
+  - Entry with only IPA (no audio) → returns None
+  - Entry with ogg_url but no mp3_url → returns None
+  - Empty sounds array → returns None
+
+### Acceptance Criteria
+
+- [x] `DictionaryEntry` has `audio_url: str | None` field
+- [x] First available `mp3_url` is extracted from kaikki data
+- [x] Entries without audio have `audio_url=None`
+- [x] All tests pass, ruff/mypy clean
+
+---
+
+## Phase 2: Media Cache Module
+
+Create a reusable module for downloading and caching media files.
+
+### Changes
+
+**src/vocab/media_cache.py** (new file)
+- `DEFAULT_CACHE_DIR = Path.home() / ".cache" / "vocab" / "media"`
+- `async def fetch_media(url: str, filename: str, cache_dir: Path | None = None) -> Path`
+  - Computes tiered path: `{cache_dir}/{filename[:2]}/{filename}`
+  - Returns cached path immediately if file exists
+  - Downloads via `httpx.AsyncClient` if not cached
+  - Creates parent directories as needed
+  - Returns the local file path
+- Uses tiered directory structure to avoid filesystem slowdown with many files
+
+**tests/test_media_cache.py** (new file)
+- Test successful download and caching
+- Test cache hit (no network request on second call)
+- Test tiered directory structure (`ab/abcdef.mp3`)
+- Test download failure raises appropriate exception
+- Test custom cache_dir parameter
+
+### Acceptance Criteria
+
+- [x] `fetch_media()` downloads and caches files
+- [x] Tiered directory structure: `{cache_dir}/{filename[:2]}/{filename}`
+- [x] Cache hits skip network requests
+- [x] All tests pass, ruff/mypy clean
+
+---
+
+## Phase 3: Async Anki Builder with Audio
+
+Make `AnkiDeckBuilder` async and integrate audio download/embedding.
+
+### Changes
+
+**src/vocab/anki.py**
+- Convert `AnkiDeckBuilder` to async context manager (`__aenter__`/`__aexit__`)
+- Add `max_concurrent_downloads: int = 16` constructor parameter
+- Add `_download_semaphore: asyncio.Semaphore` instance variable
+- Add `_media_files: list[str]` to track downloaded audio paths
+- Convert `add()` to `async def add()`:
+  - If `entry.word.audio_url` exists:
+    - Compute filename as `{guid}.mp3`
+    - Acquire semaphore, call `fetch_media()` from `media_cache` module
+    - Add path to `_media_files`
+    - Set `Audio` field to `[sound:{filename}]`
+  - Handle download failures gracefully (log warning, continue without audio)
+  - Add note to deck (unchanged)
+- Update `__aexit__` to pass `media_files` to `genanki.Package`
+- Add `Audio` field to model fields list
+- Update `BACK_TEMPLATE` to include `{{Audio}}` near the word/IPA
+
+**tests/test_anki.py**
+- Update existing tests to use `async with` and `await deck.add()`
+- Add test for audio download and embedding:
+  - Mock `fetch_media` to return a path
+  - Verify `[sound:...]` appears in card field
+  - Verify media file is included in package
+- Add test for missing audio URL (card still works)
+- Add test for download failure (logs warning, card still works)
+
+**README.md**
+- Update "Export to Anki" example to use `async with` and `await`
+- Mention audio support in Features section
+
+### Acceptance Criteria
+
+- [x] `AnkiDeckBuilder` is an async context manager
+- [x] `add()` is async and downloads audio with concurrency limit (default 16)
+- [x] Audio downloaded via `media_cache.fetch_media()`
+- [x] Cards include `[sound:{guid}.mp3]` when audio available
+- [x] Cards work normally when audio unavailable or download fails
+- [x] All tests pass, ruff/mypy clean, coverage maintained
+- [x] README updated with async usage
+
+---
+
+## Future Considerations (Out of Scope)
+
+- Multiple audio files per card (random selection would require JS)
+- Audio quality preferences (some kaikki entries have multiple recordings)
+- Offline mode / pre-download all audio for a language

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dev = [
     "pytest-cov>=6.0.0",
     "python-dotenv>=1.2.1",
     "ruff>=0.14.14",
+    "tqdm>=4.67.2",
+    "types-tqdm>=4.67.2.20260202",
 ]
 
 [tool.pyright]

--- a/src/vocab/dictionary.py
+++ b/src/vocab/dictionary.py
@@ -112,6 +112,7 @@ class DictionaryEntry:
         etymology: Etymology text, if available.
         senses: List of word senses with translations and examples.
         word_display: Expanded headword with grammatical info (e.g., "durée f (plural durées)").
+        audio_url: URL to MP3 audio pronunciation, if available.
     """
 
     word: str
@@ -120,6 +121,7 @@ class DictionaryEntry:
     etymology: str | None
     senses: list[DictionarySense]
     word_display: str | None = None
+    audio_url: str | None = None
 
     @classmethod
     def from_kaikki(cls, raw: dict[str, Any]) -> DictionaryEntry:
@@ -131,6 +133,7 @@ class DictionaryEntry:
             etymology=raw.get("etymology_text"),
             senses=[DictionarySense.from_kaikki(s) for s in raw.get("senses", [])],
             word_display=cls._extract_word_display(raw),
+            audio_url=cls._extract_audio_url(raw),
         )
 
     @staticmethod
@@ -154,6 +157,19 @@ class DictionaryEntry:
             if template.get("name") in SUPPORTED_HEAD_TEMPLATES:
                 expansion: str | None = template.get("expansion")
                 return expansion
+        return None
+
+    @staticmethod
+    def _extract_audio_url(raw: dict[str, Any]) -> str | None:
+        """Extract first available MP3 audio URL from sounds.
+
+        Returns the first mp3_url found in the sounds array, or None
+        if no MP3 audio is available.
+        """
+        for sound in raw.get("sounds", []):
+            mp3_url = sound.get("mp3_url")
+            if isinstance(mp3_url, str) and mp3_url:
+                return mp3_url
         return None
 
 

--- a/src/vocab/media_cache.py
+++ b/src/vocab/media_cache.py
@@ -1,0 +1,119 @@
+"""Media file downloading and caching."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "vocab" / "media"
+DEFAULT_TIMEOUT = 30.0
+CHUNK_SIZE = 8192
+USER_AGENT = "vocab/1.0 (https://github.com/jlopez/vocab)"
+MAX_RETRIES = 5
+INITIAL_BACKOFF = 1.0  # seconds
+
+
+async def fetch_media(
+    url: str,
+    filename: str,
+    cache_dir: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Path | None:
+    """Download and cache a media file.
+
+    Uses a tiered directory structure ({cache_dir}/{filename[:2]}/{filename})
+    to avoid filesystem slowdown with many files.
+
+    Args:
+        url: URL to download from.
+        filename: Filename to save as (e.g., "abc123.mp3"). Must not be empty.
+        cache_dir: Cache directory. Defaults to ~/.cache/vocab/media/
+        timeout: Request timeout in seconds. Defaults to 30.
+
+    Returns:
+        Path to the cached file, or None if the file was not found (404).
+
+    Raises:
+        httpx.HTTPStatusError: If download fails with non-2xx status (except 404).
+        httpx.RequestError: If network request fails.
+        ValueError: If filename is empty.
+    """
+    if not filename:
+        raise ValueError("filename must not be empty")
+
+    cache_dir = cache_dir or DEFAULT_CACHE_DIR
+
+    # Tiered path: first 2 chars of filename as subdirectory
+    tier = filename[:2] if len(filename) >= 2 else filename
+    file_path = cache_dir / tier / filename
+
+    # Return immediately if cached
+    if file_path.exists():
+        return file_path
+
+    # Download and cache atomically
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    headers = {"User-Agent": USER_AGENT}
+    async with httpx.AsyncClient(timeout=timeout, headers=headers) as client:
+        found = await _download_with_retry(client, url, file_path)
+
+    return file_path if found else None
+
+
+async def _download_with_retry(client: httpx.AsyncClient, url: str, file_path: Path) -> bool:
+    """Download a file with retry logic for rate limiting.
+
+    Retries with exponential backoff on 429 errors, respecting Retry-After header.
+
+    Args:
+        client: httpx async client to use.
+        url: URL to download from.
+        file_path: Destination path for the file.
+
+    Returns:
+        True if download succeeded, False if file not found (404).
+
+    Raises:
+        httpx.HTTPStatusError: If download fails with non-2xx status (except 404).
+    """
+    backoff = INITIAL_BACKOFF
+
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            async with client.stream("GET", url, follow_redirects=True) as response:
+                response.raise_for_status()
+
+                # Write to temp file, then atomically rename
+                with tempfile.NamedTemporaryFile(dir=file_path.parent, delete=False) as tmp:
+                    async for chunk in response.aiter_bytes(CHUNK_SIZE):
+                        tmp.write(chunk)
+                    tmp_path = Path(tmp.name)
+
+                tmp_path.rename(file_path)
+                return True
+
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return False
+            if e.response.status_code != 429 or attempt == MAX_RETRIES:
+                raise
+
+            # Get retry delay from header or use exponential backoff
+            retry_after = e.response.headers.get("Retry-After")
+            if retry_after and retry_after.isdigit():
+                delay = float(retry_after)
+            else:
+                delay = backoff
+                backoff *= 2  # Exponential backoff
+
+            logger.debug("Rate limited, retrying in %.1fs (attempt %d)", delay, attempt + 1)
+            await asyncio.sleep(delay)
+
+    return False  # Should not reach here, but satisfies type checker

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -244,6 +244,7 @@ class TestDictionaryEntry:
         assert entry.etymology is None
         assert entry.senses == []
         assert entry.word_display is None
+        assert entry.audio_url is None
 
     def test_from_kaikki_word_display_with_supported_template(self) -> None:
         """Test extracting word_display from supported head template."""
@@ -298,6 +299,80 @@ class TestDictionaryEntry:
         }
         entry = DictionaryEntry.from_kaikki(raw)
         assert entry.word_display == "correct f"
+
+    def test_from_kaikki_audio_url_with_mp3(self) -> None:
+        """Test extracting audio URL when mp3_url is available."""
+        raw = {
+            "word": "chien",
+            "pos": "noun",
+            "sounds": [
+                {"ipa": "/ʃjɛ̃/"},
+                {
+                    "mp3_url": "https://example.com/chien.mp3",
+                    "ogg_url": "https://example.com/chien.ogg",
+                },
+            ],
+            "senses": [],
+        }
+        entry = DictionaryEntry.from_kaikki(raw)
+        assert entry.audio_url == "https://example.com/chien.mp3"
+
+    def test_from_kaikki_audio_url_first_mp3(self) -> None:
+        """Test that first mp3_url is returned when multiple exist."""
+        raw = {
+            "word": "test",
+            "pos": "noun",
+            "sounds": [
+                {"mp3_url": "https://example.com/first.mp3"},
+                {"mp3_url": "https://example.com/second.mp3"},
+            ],
+            "senses": [],
+        }
+        entry = DictionaryEntry.from_kaikki(raw)
+        assert entry.audio_url == "https://example.com/first.mp3"
+
+    def test_from_kaikki_audio_url_only_ipa(self) -> None:
+        """Test that audio_url is None when only IPA is available."""
+        raw = {
+            "word": "test",
+            "pos": "noun",
+            "sounds": [{"ipa": "/tɛst/"}],
+            "senses": [],
+        }
+        entry = DictionaryEntry.from_kaikki(raw)
+        assert entry.audio_url is None
+
+    def test_from_kaikki_audio_url_only_ogg(self) -> None:
+        """Test that audio_url is None when only ogg_url is available."""
+        raw = {
+            "word": "test",
+            "pos": "noun",
+            "sounds": [{"ogg_url": "https://example.com/test.ogg"}],
+            "senses": [],
+        }
+        entry = DictionaryEntry.from_kaikki(raw)
+        assert entry.audio_url is None
+
+    def test_from_kaikki_audio_url_empty_sounds(self) -> None:
+        """Test that audio_url is None when sounds array is empty."""
+        raw = {
+            "word": "test",
+            "pos": "noun",
+            "sounds": [],
+            "senses": [],
+        }
+        entry = DictionaryEntry.from_kaikki(raw)
+        assert entry.audio_url is None
+
+    def test_from_kaikki_audio_url_no_sounds(self) -> None:
+        """Test that audio_url is None when sounds key is missing."""
+        raw = {
+            "word": "test",
+            "pos": "noun",
+            "senses": [],
+        }
+        entry = DictionaryEntry.from_kaikki(raw)
+        assert entry.audio_url is None
 
 
 class TestSpacyToKaikkiMapping:

--- a/tests/test_media_cache.py
+++ b/tests/test_media_cache.py
@@ -1,0 +1,402 @@
+"""Tests for the media_cache module."""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from vocab.media_cache import (
+    CHUNK_SIZE,
+    DEFAULT_CACHE_DIR,
+    DEFAULT_TIMEOUT,
+    USER_AGENT,
+    fetch_media,
+)
+
+
+def _make_mock_client(content: bytes) -> MagicMock:
+    """Create a mock httpx client with streaming response.
+
+    Returns a MagicMock that simulates httpx.AsyncClient with a
+    stream() method returning an async context manager.
+    """
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+
+    # Create async iterator for aiter_bytes
+    async def aiter_bytes(chunk_size: int = CHUNK_SIZE) -> AsyncIterator[bytes]:
+        for i in range(0, len(content), chunk_size):
+            yield content[i : i + chunk_size]
+
+    mock_response.aiter_bytes = aiter_bytes
+
+    mock_client = MagicMock()
+
+    @asynccontextmanager
+    async def mock_stream(method: str, url: str, **kwargs: object) -> AsyncIterator[MagicMock]:
+        yield mock_response
+
+    mock_client.stream = mock_stream
+    mock_client._response = mock_response  # For test assertions
+    return mock_client
+
+
+class TestFetchMedia:
+    """Tests for fetch_media function."""
+
+    async def test_downloads_and_caches_file(self, tmp_path: Path) -> None:
+        """Test successful download and caching."""
+        mock_client = _make_mock_client(b"fake audio content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/audio.mp3",
+                "abc123.mp3",
+                cache_dir=tmp_path,
+            )
+
+            assert result == tmp_path / "ab" / "abc123.mp3"
+            assert result.exists()
+            assert result.read_bytes() == b"fake audio content"
+
+    async def test_cache_hit_skips_download(self, tmp_path: Path) -> None:
+        """Test that cached files are returned without network request."""
+        # Pre-create cached file
+        cached_path = tmp_path / "ab" / "abc123.mp3"
+        cached_path.parent.mkdir(parents=True)
+        cached_path.write_bytes(b"cached content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            result = await fetch_media(
+                "https://example.com/audio.mp3",
+                "abc123.mp3",
+                cache_dir=tmp_path,
+            )
+
+            assert result == cached_path
+            assert result.read_bytes() == b"cached content"
+            # Should not have made any network request
+            mock_client_class.assert_not_called()
+
+    async def test_tiered_directory_structure(self, tmp_path: Path) -> None:
+        """Test that files are stored in tiered directories."""
+        mock_client = _make_mock_client(b"content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/audio.mp3",
+                "xyz789.mp3",
+                cache_dir=tmp_path,
+            )
+
+            # Should be in xy/ subdirectory
+            assert result == tmp_path / "xy" / "xyz789.mp3"
+            assert result.parent.name == "xy"
+
+    async def test_short_filename_tiering(self, tmp_path: Path) -> None:
+        """Test tiering with single-character filename prefix."""
+        mock_client = _make_mock_client(b"content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/x",
+                "x",
+                cache_dir=tmp_path,
+            )
+
+            # Single char filename uses itself as tier
+            assert result == tmp_path / "x" / "x"
+
+    async def test_404_returns_none(self, tmp_path: Path) -> None:
+        """Test that 404 returns None instead of raising."""
+        mock_client = MagicMock()
+        mock_response_404 = MagicMock()
+        mock_response_404.status_code = 404
+
+        @asynccontextmanager
+        async def mock_stream_error(
+            method: str, url: str, **kwargs: object
+        ) -> AsyncIterator[MagicMock]:
+            raise httpx.HTTPStatusError(
+                "Not Found",
+                request=httpx.Request("GET", url),
+                response=mock_response_404,
+            )
+            yield
+
+        mock_client.stream = mock_stream_error
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/missing.mp3",
+                "missing.mp3",
+                cache_dir=tmp_path,
+            )
+
+            assert result is None
+
+    async def test_server_error_raises(self, tmp_path: Path) -> None:
+        """Test that server errors (5xx) still raise."""
+        mock_client = MagicMock()
+        mock_response_500 = MagicMock()
+        mock_response_500.status_code = 500
+
+        @asynccontextmanager
+        async def mock_stream_error(
+            method: str, url: str, **kwargs: object
+        ) -> AsyncIterator[MagicMock]:
+            raise httpx.HTTPStatusError(
+                "Internal Server Error",
+                request=httpx.Request("GET", url),
+                response=mock_response_500,
+            )
+            yield
+
+        mock_client.stream = mock_stream_error
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_media(
+                    "https://example.com/error.mp3",
+                    "error.mp3",
+                    cache_dir=tmp_path,
+                )
+
+    async def test_network_error_raises(self, tmp_path: Path) -> None:
+        """Test that network errors are propagated."""
+        mock_client = MagicMock()
+
+        @asynccontextmanager
+        async def mock_stream_network_error(
+            method: str, url: str, **kwargs: object
+        ) -> AsyncIterator[MagicMock]:
+            raise httpx.ConnectError("Connection refused")
+            yield  # pragma: no cover
+
+        mock_client.stream = mock_stream_network_error
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(httpx.ConnectError):
+                await fetch_media(
+                    "https://example.com/audio.mp3",
+                    "audio.mp3",
+                    cache_dir=tmp_path,
+                )
+
+    async def test_custom_cache_dir(self, tmp_path: Path) -> None:
+        """Test using custom cache directory."""
+        custom_cache = tmp_path / "custom" / "cache"
+        mock_client = _make_mock_client(b"content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/audio.mp3",
+                "test.mp3",
+                cache_dir=custom_cache,
+            )
+
+            assert result is not None
+            assert result.is_relative_to(custom_cache)
+            assert result.exists()
+
+    async def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        """Test that parent directories are created as needed."""
+        deep_cache = tmp_path / "deep" / "nested" / "cache"
+        assert not deep_cache.exists()
+
+        mock_client = _make_mock_client(b"content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/audio.mp3",
+                "file.mp3",
+                cache_dir=deep_cache,
+            )
+
+            assert result is not None
+            assert result.exists()
+            assert deep_cache.exists()
+
+    async def test_empty_filename_raises(self, tmp_path: Path) -> None:
+        """Test that empty filename raises ValueError."""
+        with pytest.raises(ValueError, match="filename must not be empty"):
+            await fetch_media(
+                "https://example.com/audio.mp3",
+                "",
+                cache_dir=tmp_path,
+            )
+
+    async def test_custom_timeout(self, tmp_path: Path) -> None:
+        """Test that custom timeout is passed to httpx client."""
+        mock_client = _make_mock_client(b"content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await fetch_media(
+                "https://example.com/audio.mp3",
+                "test.mp3",
+                cache_dir=tmp_path,
+                timeout=60.0,
+            )
+
+            mock_client_class.assert_called_once_with(
+                timeout=60.0, headers={"User-Agent": USER_AGENT}
+            )
+
+    async def test_default_timeout(self, tmp_path: Path) -> None:
+        """Test that default timeout is used when not specified."""
+        mock_client = _make_mock_client(b"content")
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await fetch_media(
+                "https://example.com/audio.mp3",
+                "test.mp3",
+                cache_dir=tmp_path,
+            )
+
+            mock_client_class.assert_called_once_with(
+                timeout=DEFAULT_TIMEOUT, headers={"User-Agent": USER_AGENT}
+            )
+
+
+class TestDefaultCacheDir:
+    """Tests for DEFAULT_CACHE_DIR constant."""
+
+    def test_default_cache_dir_location(self) -> None:
+        """Test that default cache dir is in expected location."""
+        assert Path.home() / ".cache" / "vocab" / "media" == DEFAULT_CACHE_DIR
+
+
+class TestRetryBehavior:
+    """Tests for 429 retry behavior."""
+
+    async def test_retries_on_429_then_succeeds(self, tmp_path: Path) -> None:
+        """Test that 429 errors trigger retry and eventual success."""
+        mock_response_429 = MagicMock()
+        mock_response_429.status_code = 429
+        mock_response_429.headers = {}
+
+        call_count = 0
+
+        async def aiter_bytes(chunk_size: int = CHUNK_SIZE) -> AsyncIterator[bytes]:
+            yield b"audio content"
+
+        @asynccontextmanager
+        async def mock_stream(method: str, url: str, **kwargs: object) -> AsyncIterator[MagicMock]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response_429)
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.aiter_bytes = aiter_bytes
+            yield mock_response
+
+        mock_client = MagicMock()
+        mock_client.stream = mock_stream
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_class,
+            patch("vocab.media_cache.asyncio.sleep") as mock_sleep,
+        ):
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            result = await fetch_media(
+                "https://example.com/audio.mp3",
+                "test.mp3",
+                cache_dir=tmp_path,
+            )
+
+            assert result is not None
+            assert result.exists()
+            assert call_count == 2
+            mock_sleep.assert_called_once()
+
+    async def test_respects_retry_after_header(self, tmp_path: Path) -> None:
+        """Test that Retry-After header value is used for delay."""
+        mock_response_429 = MagicMock()
+        mock_response_429.status_code = 429
+        mock_response_429.headers = {"Retry-After": "5"}
+
+        call_count = 0
+
+        async def aiter_bytes(chunk_size: int = CHUNK_SIZE) -> AsyncIterator[bytes]:
+            yield b"content"
+
+        @asynccontextmanager
+        async def mock_stream(method: str, url: str, **kwargs: object) -> AsyncIterator[MagicMock]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response_429)
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.aiter_bytes = aiter_bytes
+            yield mock_response
+
+        mock_client = MagicMock()
+        mock_client.stream = mock_stream
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_class,
+            patch("vocab.media_cache.asyncio.sleep") as mock_sleep,
+        ):
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            await fetch_media(
+                "https://example.com/audio.mp3",
+                "test.mp3",
+                cache_dir=tmp_path,
+            )
+
+            # Should use Retry-After value of 5 seconds
+            mock_sleep.assert_called_once_with(5.0)
+
+    async def test_gives_up_after_max_retries(self, tmp_path: Path) -> None:
+        """Test that error is raised after max retries exhausted."""
+        mock_response_429 = MagicMock()
+        mock_response_429.status_code = 429
+        mock_response_429.headers = {}
+
+        @asynccontextmanager
+        async def mock_stream(method: str, url: str, **kwargs: object) -> AsyncIterator[MagicMock]:
+            raise httpx.HTTPStatusError("429", request=MagicMock(), response=mock_response_429)
+            yield
+
+        mock_client = MagicMock()
+        mock_client.stream = mock_stream
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_class,
+            patch("vocab.media_cache.asyncio.sleep"),
+        ):
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await fetch_media(
+                    "https://example.com/audio.mp3",
+                    "test.mp3",
+                    cache_dir=tmp_path,
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -1495,6 +1495,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-requests"
+version = "2.32.4.20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.67.2.20260202"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/6a/a9e27944f2715940cf7b43b35a2b464d968d086723414983e47af3261e2d/types_tqdm-4.67.2.20260202.tar.gz", hash = "sha256:c3c494ae8dfd2946fa1fe089ce6931a85bb88d9078da0d65c6b99b6643f7561d", size = 17418, upload-time = "2026-02-02T04:11:26.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f4/d24e5216630081356fd9427cb9fb4c94e3c6cfde4d4d46db2c6717e286ae/types_tqdm-4.67.2.20260202-py3-none-any.whl", hash = "sha256:01b31780b2a2cdad8465a3e53a06fdf53a47abab0d46d69c1b2039197ffd55b0", size = 23893, upload-time = "2026-02-02T04:11:25.007Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1563,6 +1587,8 @@ dev = [
     { name = "pytest-cov" },
     { name = "python-dotenv" },
     { name = "ruff" },
+    { name = "tqdm" },
+    { name = "types-tqdm" },
 ]
 
 [package.metadata]
@@ -1587,6 +1613,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "ruff", specifier = ">=0.14.14" },
+    { name = "tqdm", specifier = ">=4.67.2" },
+    { name = "types-tqdm", specifier = ">=4.67.2.20260202" },
 ]
 
 [[package]]


### PR DESCRIPTION
Extract audio URLs from kaikki dictionary data and embed MP3 files in
generated Anki packages. Audio plays automatically when reviewing cards.

Changes:
- Add audio_url field to DictionaryEntry, extracted from kaikki sounds[]
- Add media_cache module for downloading/caching audio files
- Convert AnkiDeckBuilder to async context manager for concurrent downloads
- Cache audio in ~/.cache/vocab/media/ with tiered directory structure
- Cards gracefully degrade when audio unavailable or download fails

The async API uses semaphore-limited concurrency (default 16) to avoid
overwhelming servers while keeping deck generation fast.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
