### PR TITLE
feat(cli): add vocab build command for epub-to-Anki pipeline (#27)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,13 @@ dependencies = [
     "httpx>=0.28.1",
     "lxml>=6.0.2",
     "pydantic>=2.12.5",
+    "python-dotenv>=1.2.1",
     "spacy>=3.8.11",
+    "typer>=0.21.1",
 ]
+
+[project.scripts]
+vocab = "vocab.cli:main"
 
 [build-system]
 requires = ["uv_build>=0.9.15,<0.10.0"]
@@ -26,11 +31,11 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",
+    "pip>=26.0.1",
     "pre-commit>=4.5.1",
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=6.0.0",
-    "python-dotenv>=1.2.1",
     "ruff>=0.14.14",
     "tqdm>=4.67.2",
     "types-tqdm>=4.67.2.20260202",

--- a/src/vocab/__init__.py
+++ b/src/vocab/__init__.py
@@ -1,6 +1,7 @@
 """Vocabulary extraction from ePub files."""
 
 from vocab.anki import AnkiDeckBuilder
+from vocab.artifacts import ArtifactWriter, NullArtifactWriter
 from vocab.dictionary import (
     SPACY_TO_KAIKKI,
     Dictionary,
@@ -28,10 +29,11 @@ from vocab.pipeline import (
 )
 from vocab.sentences import SpacyModelNotFoundError, extract_sentences
 from vocab.tokens import extract_tokens
-from vocab.vocabulary import build_vocabulary
+from vocab.vocabulary import VocabularyBuilder, build_vocabulary
 
 __all__ = [
     "AnkiDeckBuilder",
+    "ArtifactWriter",
     "Chapter",
     "Dictionary",
     "DictionaryEntry",
@@ -40,6 +42,7 @@ __all__ = [
     "EnrichedLemma",
     "Example",
     "LemmaEntry",
+    "NullArtifactWriter",
     "SPACY_TO_KAIKKI",
     "Sentence",
     "SenseAssignment",
@@ -47,6 +50,7 @@ __all__ = [
     "SpacyModelNotFoundError",
     "Token",
     "Vocabulary",
+    "VocabularyBuilder",
     "assign_single_sense",
     "build_vocabulary",
     "disambiguate_senses",

--- a/src/vocab/anki.py
+++ b/src/vocab/anki.py
@@ -243,6 +243,7 @@ class AnkiDeckBuilder:
         source_language: str,
         max_concurrent_downloads: int = 16,
         cache_dir: Path | None = None,
+        skip_audio: bool = False,
     ) -> None:
         """Initialize the deck builder.
 
@@ -252,11 +253,13 @@ class AnkiDeckBuilder:
             source_language: Source language code (e.g., "fr").
             max_concurrent_downloads: Max concurrent audio downloads (default 16).
             cache_dir: Cache directory for audio files. Defaults to ~/.cache/vocab/media/
+            skip_audio: If True, skip audio downloads even when URLs are available.
         """
         self._path = path
         self._deck_name = deck_name
         self._source_language = source_language
         self._cache_dir = cache_dir
+        self._skip_audio = skip_audio
         self._download_semaphore = asyncio.Semaphore(max_concurrent_downloads)
         self._media_files: list[str] = []
 
@@ -317,7 +320,7 @@ class AnkiDeckBuilder:
 
         # Download audio if available
         audio = ""
-        if entry.word.audio_url:
+        if entry.word.audio_url and not self._skip_audio:
             audio = await self._download_audio(entry.word.audio_url, guid)
 
         note = genanki.Note(

--- a/src/vocab/artifacts.py
+++ b/src/vocab/artifacts.py
@@ -1,0 +1,162 @@
+"""Intermediate artifact writers for pipeline debugging."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from io import TextIOWrapper
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Self
+
+from vocab.models import Chapter, LemmaEntry, Sentence, Token, Vocabulary
+from vocab.pipeline import EnrichedLemma, SenseAssignment
+
+
+class ArtifactWriter:
+    """Context manager that writes numbered JSONL/JSON pipeline artifacts.
+
+    Writes intermediate pipeline outputs to a directory for debugging
+    and reproducibility. Files are named with numeric prefixes to reflect
+    the pipeline stage order.
+
+    Usage:
+        with ArtifactWriter(Path("artifacts/")) as artifacts:
+            artifacts.write_chapter(chapter)
+            ...
+    """
+
+    def __init__(self, directory: Path) -> None:
+        """Initialize the artifact writer.
+
+        Args:
+            directory: Directory to write artifacts to. Created if it doesn't exist.
+        """
+        self._directory = directory
+        self._handles: dict[str, TextIOWrapper] = {}
+
+    def __enter__(self) -> Self:
+        """Enter context: create directory."""
+        self._directory.mkdir(parents=True, exist_ok=True)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context: close all open file handles."""
+        for handle in self._handles.values():
+            handle.close()
+        self._handles.clear()
+
+    def _get_handle(self, filename: str) -> TextIOWrapper:
+        """Get or open a file handle for the given filename."""
+        if filename not in self._handles:
+            path = self._directory / filename
+            self._handles[filename] = open(path, "w", encoding="utf-8")  # noqa: SIM115
+        return self._handles[filename]
+
+    def _write_jsonl(self, filename: str, data: Any) -> None:
+        """Write a single JSON line to the named file."""
+        handle = self._get_handle(filename)
+        handle.write(json.dumps(asdict(data), ensure_ascii=False) + "\n")
+
+    def write_chapter(self, chapter: Chapter) -> None:
+        """Write a chapter to 01-chapters.jsonl."""
+        self._write_jsonl("01-chapters.jsonl", chapter)
+
+    def write_sentence(self, chapter: Chapter, sentence: Sentence) -> None:
+        """Write a sentence record to 02-sentences.jsonl."""
+        record = {
+            "chapter_index": chapter.index,
+            "chapter_title": chapter.title,
+            "sentence_index": sentence.index,
+            "text": sentence.text,
+        }
+        handle = self._get_handle("02-sentences.jsonl")
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    def write_token(self, token: Token) -> None:
+        """Write a token to 03-tokens.jsonl."""
+        self._write_jsonl("03-tokens.jsonl", token)
+
+    def write_vocabulary(self, vocab: Vocabulary) -> None:
+        """Write vocabulary to 04-vocabulary.json."""
+        handle = self._get_handle("04-vocabulary.json")
+        json.dump(vocab.to_dict(), handle, ensure_ascii=False, indent=2)
+
+    def write_enriched(self, enriched: EnrichedLemma) -> None:
+        """Write an enriched lemma to 05-enriched.jsonl."""
+        self._write_jsonl("05-enriched.jsonl", enriched)
+
+    def write_rejected(self, entry: LemmaEntry) -> None:
+        """Write a rejected lemma to 05-rejected.jsonl."""
+        self._write_jsonl("05-rejected.jsonl", entry)
+
+    def write_assigned(self, assignment: SenseAssignment) -> None:
+        """Write an unambiguous sense assignment to 06-assigned.jsonl."""
+        self._write_jsonl("06-assigned.jsonl", assignment)
+
+    def write_ambiguous(self, enriched: EnrichedLemma) -> None:
+        """Write an ambiguous enriched lemma to 06-ambiguous.jsonl."""
+        self._write_jsonl("06-ambiguous.jsonl", enriched)
+
+    def write_disambiguated(self, assignment: SenseAssignment) -> None:
+        """Write a disambiguated sense assignment to 07-disambiguated.jsonl."""
+        self._write_jsonl("07-disambiguated.jsonl", assignment)
+
+    def write_failed(self, enriched: EnrichedLemma) -> None:
+        """Write a failed disambiguation to 07-failed.jsonl."""
+        self._write_jsonl("07-failed.jsonl", enriched)
+
+
+class NullArtifactWriter:
+    """No-op artifact writer (null object pattern).
+
+    Drop-in replacement for ArtifactWriter that writes nothing.
+    Used when --artifacts is not provided.
+    """
+
+    def __enter__(self) -> Self:
+        """Enter context (no-op)."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context (no-op)."""
+
+    def write_chapter(self, chapter: Chapter) -> None:
+        """No-op."""
+
+    def write_sentence(self, chapter: Chapter, sentence: Sentence) -> None:
+        """No-op."""
+
+    def write_token(self, token: Token) -> None:
+        """No-op."""
+
+    def write_vocabulary(self, vocab: Vocabulary) -> None:
+        """No-op."""
+
+    def write_enriched(self, enriched: EnrichedLemma) -> None:
+        """No-op."""
+
+    def write_rejected(self, entry: LemmaEntry) -> None:
+        """No-op."""
+
+    def write_assigned(self, assignment: SenseAssignment) -> None:
+        """No-op."""
+
+    def write_ambiguous(self, enriched: EnrichedLemma) -> None:
+        """No-op."""
+
+    def write_disambiguated(self, assignment: SenseAssignment) -> None:
+        """No-op."""
+
+    def write_failed(self, enriched: EnrichedLemma) -> None:
+        """No-op."""

--- a/src/vocab/cli.py
+++ b/src/vocab/cli.py
@@ -1,0 +1,292 @@
+"""CLI for vocab — build Anki decks from ePub files."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from dotenv import load_dotenv
+
+from vocab.anki import AnkiDeckBuilder
+from vocab.artifacts import ArtifactWriter, NullArtifactWriter
+from vocab.dictionary import KAIKKI_URLS, LANGUAGE_NAMES, Dictionary
+from vocab.epub import extract_chapters
+from vocab.models import LemmaEntry, SentenceLocation
+from vocab.pipeline import (
+    assign_single_sense,
+    disambiguate_senses,
+    enrich_lemma,
+    needs_disambiguation,
+)
+from vocab.sentences import extract_sentences
+from vocab.tokens import extract_tokens
+from vocab.vocabulary import VocabularyBuilder
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="vocab",
+    no_args_is_help=True,
+)
+
+
+@app.callback()
+def _callback() -> None:
+    """Build Anki decks from ePub files."""
+
+
+# Default POS tags to include in the deck
+DEFAULT_POS = "NOUN,VERB,ADJ,ADV"
+
+
+def _validate_language(language: str) -> str:
+    """Validate language code is supported by both dictionary and LLM pipeline."""
+    if language not in KAIKKI_URLS:
+        supported = ", ".join(sorted(KAIKKI_URLS.keys()))
+        raise typer.BadParameter(f"Unsupported language: {language}. Supported: {supported}")
+    return language
+
+
+def _resolve_deck_name(deck_name: str | None, language: str) -> str:
+    """Resolve deck name, defaulting to '{Language} Vocabulary'."""
+    if deck_name:
+        return deck_name
+    language_name = LANGUAGE_NAMES.get(language, language.upper())
+    return f"{language_name} Vocabulary"
+
+
+@app.command()
+def build(
+    epub: Annotated[
+        Path,
+        typer.Argument(help="Path to the input ePub file.", exists=True, readable=True),
+    ],
+    language: Annotated[
+        str,
+        typer.Option("--language", "-l", help="2-letter language code (e.g., fr, de, es)."),
+    ],
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", "-o", help="Output .apkg file path."),
+    ] = None,
+    deck_name: Annotated[
+        str | None,
+        typer.Option("--deck-name", "-d", help="Anki deck name."),
+    ] = None,
+    artifacts: Annotated[
+        Path | None,
+        typer.Option("--artifacts", help="Directory for intermediate pipeline artifacts."),
+    ] = None,
+    top: Annotated[
+        int | None,
+        typer.Option("--top", "-t", help="Limit to N most frequent lemmas.", min=1),
+    ] = None,
+    max_examples: Annotated[
+        int,
+        typer.Option("--max-examples", "-n", help="Max example sentences per lemma.", min=0),
+    ] = 3,
+    pos: Annotated[
+        str,
+        typer.Option("--pos", help="Comma-separated POS tags to include."),
+    ] = DEFAULT_POS,
+    model: Annotated[
+        str,
+        typer.Option("--model", "-m", help="LLM model for disambiguation."),
+    ] = "claude-haiku",
+    no_audio: Annotated[
+        bool,
+        typer.Option("--no-audio", help="Skip audio downloads."),
+    ] = False,
+    no_disambiguation: Annotated[
+        bool,
+        typer.Option("--no-disambiguation", help="Skip LLM disambiguation step."),
+    ] = False,
+) -> None:
+    """Build an Anki deck from an ePub file.
+
+    Runs the full pipeline: extract text, build vocabulary, enrich with
+    dictionary definitions, disambiguate senses, and generate flashcards.
+    """
+    # Load .env for ANTHROPIC_API_KEY
+    load_dotenv()
+
+    # Validate inputs
+    language = _validate_language(language)
+    output_path = output or epub.with_suffix(".apkg")
+    resolved_deck_name = _resolve_deck_name(deck_name, language)
+    pos_tags = {p.strip().upper() for p in pos.split(",")}
+
+    # Check API key if disambiguation is enabled
+    if not no_disambiguation:
+        import os
+
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            typer.echo(
+                "Error: ANTHROPIC_API_KEY not set. "
+                "Set it in .env or environment, or use --no-disambiguation.",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+    asyncio.run(
+        _build_pipeline(
+            epub_path=epub,
+            language=language,
+            output_path=output_path,
+            deck_name=resolved_deck_name,
+            artifacts_dir=artifacts,
+            top_n=top,
+            max_examples=max_examples,
+            pos_tags=pos_tags,
+            model=model,
+            no_audio=no_audio,
+            no_disambiguation=no_disambiguation,
+        )
+    )
+
+
+async def _build_pipeline(
+    *,
+    epub_path: Path,
+    language: str,
+    output_path: Path,
+    deck_name: str,
+    artifacts_dir: Path | None,
+    top_n: int | None,
+    max_examples: int,
+    pos_tags: set[str],
+    model: str,
+    no_audio: bool,
+    no_disambiguation: bool,
+) -> None:
+    """Run the full build pipeline."""
+    from vocab.pipeline import EnrichedLemma, SenseAssignment
+
+    # Setup artifact writer
+    artifact_writer = ArtifactWriter(artifacts_dir) if artifacts_dir else NullArtifactWriter()
+
+    with artifact_writer:
+        # --- Phase 1-4: Build vocabulary ---
+        typer.echo(f"Building vocabulary from {epub_path.name}...")
+        builder = VocabularyBuilder(language=language, max_examples=max_examples)
+
+        for chapter in extract_chapters(epub_path):
+            artifact_writer.write_chapter(chapter)
+            for sentence in extract_sentences(chapter.text, language):
+                artifact_writer.write_sentence(chapter, sentence)
+                location = SentenceLocation(
+                    chapter_index=chapter.index,
+                    chapter_title=chapter.title,
+                    sentence_index=sentence.index,
+                )
+                for token in extract_tokens(sentence.text, location, language):
+                    artifact_writer.write_token(token)
+                    builder.add(token)
+
+        vocab = builder.build()
+        artifact_writer.write_vocabulary(vocab)
+        typer.echo(f"Found {len(vocab.entries)} unique lemmas.")
+
+        # --- Phase 5: Enrich with dictionary ---
+        typer.echo("Enriching with dictionary definitions...")
+        dictionary = Dictionary(language)
+
+        enriched_lemmas: list[EnrichedLemma] = []
+
+        # Identify which entries to keep (top-N by frequency if requested)
+        if top_n is not None:
+            pos_filtered = [e for e in vocab if e.pos in pos_tags]
+            pos_filtered.sort(key=lambda e: e.frequency, reverse=True)
+            keep = {(e.lemma, e.pos) for e in pos_filtered[:top_n]}
+        else:
+            keep = None
+
+        # Iterate in insertion order (follows book narrative)
+        candidates: list[LemmaEntry] = []
+        for lemma_entry in vocab:
+            if lemma_entry.pos not in pos_tags:
+                artifact_writer.write_rejected(lemma_entry)
+                continue
+            if keep is not None and (lemma_entry.lemma, lemma_entry.pos) not in keep:
+                continue
+            candidates.append(lemma_entry)
+
+        for lemma_entry in candidates:
+            enriched = enrich_lemma(lemma_entry, dictionary)
+            if enriched:
+                enriched_lemmas.append(enriched)
+                artifact_writer.write_enriched(enriched)
+            else:
+                artifact_writer.write_rejected(lemma_entry)
+
+        typer.echo(f"Enriched {len(enriched_lemmas)} lemmas.")
+
+        # --- Phase 6: Triage ---
+        assignments: list[SenseAssignment] = []
+        ambiguous: list[EnrichedLemma] = []
+
+        for enriched in enriched_lemmas:
+            if not needs_disambiguation(enriched):
+                assignment = assign_single_sense(enriched)
+                assignments.append(assignment)
+                artifact_writer.write_assigned(assignment)
+            else:
+                ambiguous.append(enriched)
+                artifact_writer.write_ambiguous(enriched)
+
+        typer.echo(f"Triage: {len(assignments)} unambiguous, {len(ambiguous)} ambiguous.")
+
+        # --- Phase 7: Disambiguate ---
+        if not no_disambiguation and ambiguous:
+            typer.echo(f"Disambiguating {len(ambiguous)} lemmas with {model}...")
+            disambiguated_count = 0
+            failed_count = 0
+
+            for enriched in ambiguous:
+                try:
+                    results = await disambiguate_senses(enriched, language=language, model=model)
+                    if results:
+                        for assignment in results:
+                            assignments.append(assignment)
+                            artifact_writer.write_disambiguated(assignment)
+                        disambiguated_count += 1
+                    else:
+                        artifact_writer.write_failed(enriched)
+                        failed_count += 1
+                except Exception:
+                    logger.warning("Failed to disambiguate %s", enriched.lemma.lemma, exc_info=True)
+                    artifact_writer.write_failed(enriched)
+                    failed_count += 1
+
+            typer.echo(f"Disambiguation: {disambiguated_count} succeeded, {failed_count} failed.")
+        elif ambiguous:
+            typer.echo(f"Skipping disambiguation for {len(ambiguous)} ambiguous lemmas.")
+
+        # --- Phase 8: Build Anki deck ---
+        typer.echo(f"Building Anki deck ({len(assignments)} cards)...")
+
+        async with AnkiDeckBuilder(
+            path=output_path,
+            deck_name=deck_name,
+            source_language=language,
+            skip_audio=no_audio,
+        ) as deck:
+            for assignment in assignments:
+                await deck.add(assignment)
+
+        typer.echo(f"Generated: {output_path} ({deck.cards_added} cards)")
+
+
+def main() -> None:  # pragma: no cover
+    """Entry point for the CLI."""
+    # Configure logging — only show warnings by default
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(levelname)s: %(message)s",
+        stream=sys.stderr,
+    )
+    app()

--- a/src/vocab/dictionary.py
+++ b/src/vocab/dictionary.py
@@ -58,7 +58,7 @@ LANGUAGE_NAMES: dict[str, str] = {
 DEFAULT_CACHE_DIR = Path.home() / ".cache" / "vocab"
 
 # Head template names to extract word_display from
-SUPPORTED_HEAD_TEMPLATES: set[str] = {"fr-noun"}
+SUPPORTED_HEAD_TEMPLATES: set[str] = {"fr-noun", "de-noun"}
 
 
 @dataclass

--- a/src/vocab/vocabulary.py
+++ b/src/vocab/vocabulary.py
@@ -3,12 +3,105 @@
 from pathlib import Path
 
 from vocab.epub import extract_chapters
-from vocab.models import Example, LemmaEntry, SentenceLocation, Vocabulary
+from vocab.models import Example, LemmaEntry, SentenceLocation, Token, Vocabulary
 from vocab.sentences import extract_sentences
 from vocab.tokens import extract_tokens
 
 # POS tags to skip during vocabulary building
 SKIP_POS: set[str] = {""}
+
+
+class VocabularyBuilder:
+    """Incrementally builds vocabulary from tokens.
+
+    Accumulates tokens via add(), then call build() to produce
+    a Vocabulary object with frequency counts and examples.
+    """
+
+    def __init__(self, language: str, max_examples: int = 3) -> None:
+        """Initialize the vocabulary builder.
+
+        Args:
+            language: Language code (e.g., "fr" for French).
+            max_examples: Maximum example sentences to keep per lemma (0 for none).
+
+        Raises:
+            ValueError: If max_examples < 0.
+        """
+        if max_examples < 0:
+            raise ValueError("max_examples must be >= 0")
+
+        self._language = language
+        self._max_examples = max_examples
+        self._frequency: dict[tuple[str, str], int] = {}
+        self._forms: dict[tuple[str, str], dict[str, int]] = {}
+        self._examples: dict[tuple[str, str], list[Example]] = {}
+        self._built = False
+
+    def add(self, token: Token) -> None:
+        """Add a token to the vocabulary.
+
+        Tokens with POS in SKIP_POS are silently ignored.
+
+        Args:
+            token: The token to add.
+
+        Raises:
+            RuntimeError: If build() has already been called.
+        """
+        if self._built:
+            raise RuntimeError("Cannot add tokens after build() has been called")
+        if token.pos in SKIP_POS:
+            return
+
+        key = (token.lemma, token.pos)
+
+        # Update frequency
+        self._frequency[key] = self._frequency.get(key, 0) + 1
+
+        # Update forms
+        if key not in self._forms:
+            self._forms[key] = {}
+        key_forms = self._forms[key]
+        key_forms[token.original] = key_forms.get(token.original, 0) + 1
+
+        # Add example if under limit and not a duplicate sentence
+        if key not in self._examples:
+            self._examples[key] = []
+        key_examples = self._examples[key]
+        if len(key_examples) < self._max_examples and not any(
+            ex.sentence == token.sentence for ex in key_examples
+        ):
+            key_examples.append(Example(sentence=token.sentence, location=token.location))
+
+    def build(self) -> Vocabulary:
+        """Build the final Vocabulary object from accumulated tokens.
+
+        This is a terminal operation — after calling build(), further
+        add() or build() calls will raise RuntimeError.
+
+        Returns:
+            Vocabulary object with aggregated frequency data.
+
+        Raises:
+            RuntimeError: If build() has already been called.
+        """
+        if self._built:
+            raise RuntimeError("build() has already been called")
+        self._built = True
+        entries: dict[str, dict[str, LemmaEntry]] = {}
+        for (lemma, pos), freq in self._frequency.items():
+            if lemma not in entries:
+                entries[lemma] = {}
+            entries[lemma][pos] = LemmaEntry(
+                lemma=lemma,
+                pos=pos,
+                frequency=freq,
+                forms=self._forms[(lemma, pos)],
+                examples=self._examples[(lemma, pos)],
+            )
+
+        return Vocabulary(entries=entries, language=self._language)
 
 
 def build_vocabulary(
@@ -33,64 +126,16 @@ def build_vocabulary(
         SpacyModelNotFoundError: If the spaCy model is not installed.
         ValueError: If the language code is not supported or max_examples < 0.
     """
-    if max_examples < 0:
-        raise ValueError("max_examples must be >= 0")
-
-    # Track data during aggregation, keyed by (lemma, pos) tuple
-    frequency: dict[tuple[str, str], int] = {}
-    forms: dict[tuple[str, str], dict[str, int]] = {}
-    examples: dict[tuple[str, str], list[Example]] = {}
+    builder = VocabularyBuilder(language=language, max_examples=max_examples)
 
     for chapter in extract_chapters(epub_path):
-        location_base = SentenceLocation(
-            chapter_index=chapter.index,
-            chapter_title=chapter.title,
-            sentence_index=0,  # Will be updated per sentence
-        )
-
         for sentence in extract_sentences(chapter.text, language):
             location = SentenceLocation(
-                chapter_index=location_base.chapter_index,
-                chapter_title=location_base.chapter_title,
+                chapter_index=chapter.index,
+                chapter_title=chapter.title,
                 sentence_index=sentence.index,
             )
-
             for token in extract_tokens(sentence.text, location, language):
-                # Skip tokens with blocked POS
-                if token.pos in SKIP_POS:
-                    continue
+                builder.add(token)
 
-                key = (token.lemma, token.pos)
-
-                # Update frequency
-                frequency[key] = frequency.get(key, 0) + 1
-
-                # Update forms
-                if key not in forms:
-                    forms[key] = {}
-                key_forms = forms[key]
-                key_forms[token.original] = key_forms.get(token.original, 0) + 1
-
-                # Add example if under limit and not a duplicate sentence
-                if key not in examples:
-                    examples[key] = []
-                key_examples = examples[key]
-                if len(key_examples) < max_examples and not any(
-                    ex.sentence == token.sentence for ex in key_examples
-                ):
-                    key_examples.append(Example(sentence=token.sentence, location=token.location))
-
-    # Build final vocabulary with nested structure: entries[lemma][pos] = LemmaEntry
-    entries: dict[str, dict[str, LemmaEntry]] = {}
-    for (lemma, pos), freq in frequency.items():
-        if lemma not in entries:
-            entries[lemma] = {}
-        entries[lemma][pos] = LemmaEntry(
-            lemma=lemma,
-            pos=pos,
-            frequency=freq,
-            forms=forms[(lemma, pos)],
-            examples=examples[(lemma, pos)],
-        )
-
-    return Vocabulary(entries=entries, language=language)
+    return builder.build()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,247 @@
+"""Tests for artifact writers."""
+
+import json
+from pathlib import Path
+
+from vocab.artifacts import ArtifactWriter, NullArtifactWriter
+from vocab.models import (
+    Chapter,
+    Example,
+    LemmaEntry,
+    Sentence,
+    SentenceLocation,
+    Token,
+    Vocabulary,
+)
+from vocab.pipeline import EnrichedLemma, SenseAssignment
+
+# --- Test fixtures ---
+
+_LOCATION = SentenceLocation(chapter_index=0, chapter_title="Ch 1", sentence_index=0)
+_CHAPTER = Chapter(text="Le chat dort.", index=0, title="Ch 1")
+_SENTENCE = Sentence(text="Le chat dort.", index=0)
+_TOKEN = Token(
+    lemma="chat",
+    pos="NOUN",
+    morph={},
+    original="chat",
+    sentence="Le chat dort.",
+    location=_LOCATION,
+)
+_LEMMA = LemmaEntry(
+    lemma="chat",
+    pos="NOUN",
+    frequency=5,
+    forms={"chat": 3, "chats": 2},
+    examples=[Example(sentence="Le chat dort.", location=_LOCATION)],
+)
+_VOCAB = Vocabulary(
+    entries={"chat": {"NOUN": _LEMMA}},
+    language="fr",
+)
+
+
+def _make_enriched() -> EnrichedLemma:
+    from vocab.dictionary import DictionaryEntry, DictionarySense
+
+    sense = DictionarySense(id="s1", translation="cat", example=None)
+    word = DictionaryEntry(word="chat", pos="noun", ipa="/ʃa/", etymology=None, senses=[sense])
+    return EnrichedLemma(lemma=_LEMMA, words=[word])
+
+
+def _make_assignment() -> SenseAssignment:
+    from vocab.dictionary import DictionaryEntry, DictionarySense
+
+    sense = DictionarySense(id="s1", translation="cat", example=None)
+    word = DictionaryEntry(word="chat", pos="noun", ipa="/ʃa/", etymology=None, senses=[sense])
+    return SenseAssignment(lemma=_LEMMA, examples=[0], word=word, sense=0)
+
+
+# --- ArtifactWriter tests ---
+
+
+class TestArtifactWriter:
+    """Tests for ArtifactWriter."""
+
+    def test_creates_directory(self, tmp_path: Path) -> None:
+        """Should create the output directory on enter."""
+        out = tmp_path / "artifacts"
+        with ArtifactWriter(out):
+            assert out.is_dir()
+
+    def test_write_chapter(self, tmp_path: Path) -> None:
+        """Should write chapter to 01-chapters.jsonl."""
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_chapter(_CHAPTER)
+
+        lines = (tmp_path / "01-chapters.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["index"] == 0
+        assert data["title"] == "Ch 1"
+        assert data["text"] == "Le chat dort."
+
+    def test_write_sentence(self, tmp_path: Path) -> None:
+        """Should write sentence record to 02-sentences.jsonl."""
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_sentence(_CHAPTER, _SENTENCE)
+
+        lines = (tmp_path / "02-sentences.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["chapter_index"] == 0
+        assert data["chapter_title"] == "Ch 1"
+        assert data["sentence_index"] == 0
+        assert data["text"] == "Le chat dort."
+
+    def test_write_token(self, tmp_path: Path) -> None:
+        """Should write token to 03-tokens.jsonl."""
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_token(_TOKEN)
+
+        lines = (tmp_path / "03-tokens.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["lemma"] == "chat"
+        assert data["pos"] == "NOUN"
+        assert data["original"] == "chat"
+
+    def test_write_vocabulary(self, tmp_path: Path) -> None:
+        """Should write vocabulary to 04-vocabulary.json."""
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_vocabulary(_VOCAB)
+
+        data = json.loads((tmp_path / "04-vocabulary.json").read_text())
+        assert data["language"] == "fr"
+        assert "chat" in data["entries"]
+
+    def test_write_enriched(self, tmp_path: Path) -> None:
+        """Should write enriched lemma to 05-enriched.jsonl."""
+        enriched = _make_enriched()
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_enriched(enriched)
+
+        lines = (tmp_path / "05-enriched.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["lemma"]["lemma"] == "chat"
+
+    def test_write_rejected(self, tmp_path: Path) -> None:
+        """Should write rejected lemma to 05-rejected.jsonl."""
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_rejected(_LEMMA)
+
+        lines = (tmp_path / "05-rejected.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["lemma"] == "chat"
+
+    def test_write_assigned(self, tmp_path: Path) -> None:
+        """Should write sense assignment to 06-assigned.jsonl."""
+        assignment = _make_assignment()
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_assigned(assignment)
+
+        lines = (tmp_path / "06-assigned.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["lemma"]["lemma"] == "chat"
+        assert data["sense"] == 0
+
+    def test_write_ambiguous(self, tmp_path: Path) -> None:
+        """Should write ambiguous enriched lemma to 06-ambiguous.jsonl."""
+        enriched = _make_enriched()
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_ambiguous(enriched)
+
+        lines = (tmp_path / "06-ambiguous.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["lemma"]["lemma"] == "chat"
+
+    def test_write_disambiguated(self, tmp_path: Path) -> None:
+        """Should write disambiguated assignment to 07-disambiguated.jsonl."""
+        assignment = _make_assignment()
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_disambiguated(assignment)
+
+        lines = (tmp_path / "07-disambiguated.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+
+    def test_write_failed(self, tmp_path: Path) -> None:
+        """Should write failed enriched lemma to 07-failed.jsonl."""
+        enriched = _make_enriched()
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_failed(enriched)
+
+        lines = (tmp_path / "07-failed.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 1
+
+    def test_multiple_writes_append(self, tmp_path: Path) -> None:
+        """Multiple writes to same file should append lines."""
+        ch1 = Chapter(text="First.", index=0, title="A")
+        ch2 = Chapter(text="Second.", index=1, title="B")
+
+        with ArtifactWriter(tmp_path) as artifacts:
+            artifacts.write_chapter(ch1)
+            artifacts.write_chapter(ch2)
+
+        lines = (tmp_path / "01-chapters.jsonl").read_text().strip().split("\n")
+        assert len(lines) == 2
+
+    def test_files_closed_on_exit(self, tmp_path: Path) -> None:
+        """File handles should be closed after exiting context."""
+        writer = ArtifactWriter(tmp_path)
+        with writer:
+            writer.write_chapter(_CHAPTER)
+
+        # After exit, handles should be cleared
+        assert len(writer._handles) == 0
+
+    def test_nested_directory_created(self, tmp_path: Path) -> None:
+        """Should create nested directories as needed."""
+        out = tmp_path / "a" / "b" / "c"
+        with ArtifactWriter(out) as artifacts:
+            artifacts.write_chapter(_CHAPTER)
+
+        assert (out / "01-chapters.jsonl").exists()
+
+
+# --- NullArtifactWriter tests ---
+
+
+class TestNullArtifactWriter:
+    """Tests for NullArtifactWriter."""
+
+    def test_works_as_context_manager(self) -> None:
+        """Should work as a context manager."""
+        with NullArtifactWriter() as artifacts:
+            assert artifacts is not None
+
+    def test_write_methods_are_noop(self, tmp_path: Path) -> None:
+        """All write methods should do nothing."""
+        enriched = _make_enriched()
+        assignment = _make_assignment()
+
+        with NullArtifactWriter() as artifacts:
+            artifacts.write_chapter(_CHAPTER)
+            artifacts.write_sentence(_CHAPTER, _SENTENCE)
+            artifacts.write_token(_TOKEN)
+            artifacts.write_vocabulary(_VOCAB)
+            artifacts.write_enriched(enriched)
+            artifacts.write_rejected(_LEMMA)
+            artifacts.write_assigned(assignment)
+            artifacts.write_ambiguous(enriched)
+            artifacts.write_disambiguated(assignment)
+            artifacts.write_failed(enriched)
+
+        # No files should be created anywhere
+
+    def test_no_files_created(self, tmp_path: Path) -> None:
+        """NullArtifactWriter should not create any files."""
+        out = tmp_path / "should_not_exist"
+
+        with NullArtifactWriter() as artifacts:
+            artifacts.write_chapter(_CHAPTER)
+
+        assert not out.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,495 @@
+"""Tests for the CLI."""
+
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from vocab.cli import _resolve_deck_name, _validate_language, app
+from vocab.dictionary import DictionaryEntry, DictionarySense
+from vocab.models import (
+    Chapter,
+    Example,
+    LemmaEntry,
+    Sentence,
+    SentenceLocation,
+    Token,
+    Vocabulary,
+)
+from vocab.pipeline import EnrichedLemma, SenseAssignment
+
+runner = CliRunner()
+
+# --- Test fixtures ---
+
+_LOCATION = SentenceLocation(chapter_index=0, chapter_title="Ch 1", sentence_index=0)
+_CHAPTER = Chapter(text="Le chat dort.", index=0, title="Ch 1")
+_SENTENCE = Sentence(text="Le chat dort.", index=0)
+_TOKEN = Token(
+    lemma="chat",
+    pos="NOUN",
+    morph={},
+    original="chat",
+    sentence="Le chat dort.",
+    location=_LOCATION,
+)
+_LEMMA = LemmaEntry(
+    lemma="chat",
+    pos="NOUN",
+    frequency=5,
+    forms={"chat": 3, "chats": 2},
+    examples=[Example(sentence="Le chat dort.", location=_LOCATION)],
+)
+_VOCAB = Vocabulary(
+    entries={"chat": {"NOUN": _LEMMA}},
+    language="fr",
+)
+
+
+def _make_enriched() -> EnrichedLemma:
+    sense = DictionarySense(id="s1", translation="cat", example=None)
+    word = DictionaryEntry(word="chat", pos="noun", ipa="/ʃa/", etymology=None, senses=[sense])
+    return EnrichedLemma(lemma=_LEMMA, words=[word])
+
+
+def _make_assignment() -> SenseAssignment:
+    sense = DictionarySense(id="s1", translation="cat", example=None)
+    word = DictionaryEntry(word="chat", pos="noun", ipa="/ʃa/", etymology=None, senses=[sense])
+    return SenseAssignment(lemma=_LEMMA, examples=[0], word=word, sense=0)
+
+
+# --- Validation tests ---
+
+
+class TestValidateLanguage:
+    """Tests for _validate_language."""
+
+    def test_valid_language(self) -> None:
+        assert _validate_language("fr") == "fr"
+
+    def test_invalid_language(self) -> None:
+        import pytest
+        import typer
+
+        with pytest.raises(typer.BadParameter, match="Unsupported language"):
+            _validate_language("xx")
+
+
+class TestResolveDeckName:
+    """Tests for _resolve_deck_name."""
+
+    def test_explicit_deck_name(self) -> None:
+        assert _resolve_deck_name("My Deck", "fr") == "My Deck"
+
+    def test_default_french(self) -> None:
+        assert _resolve_deck_name(None, "fr") == "French Vocabulary"
+
+    def test_default_german(self) -> None:
+        assert _resolve_deck_name(None, "de") == "German Vocabulary"
+
+    def test_unknown_language_uses_code(self) -> None:
+        assert _resolve_deck_name(None, "xx") == "XX Vocabulary"
+
+
+# --- CLI invocation tests ---
+
+
+def _enter_pipeline_mocks(
+    stack: ExitStack,
+    *,
+    enriched_return: EnrichedLemma | None = None,
+    assignment_return: SenseAssignment | None = None,
+    needs_disambig: bool = False,
+    tokens: list[Token] | None = None,
+    no_env: bool = True,
+) -> None:
+    """Enter all pipeline mocks into an ExitStack."""
+    if enriched_return is None:
+        enriched_return = _make_enriched()
+    if assignment_return is None:
+        assignment_return = _make_assignment()
+
+    stack.enter_context(patch("vocab.cli.load_dotenv"))
+    stack.enter_context(patch("vocab.cli.extract_chapters", return_value=[_CHAPTER]))
+    stack.enter_context(patch("vocab.cli.extract_sentences", return_value=[_SENTENCE]))
+    stack.enter_context(
+        patch("vocab.cli.extract_tokens", return_value=tokens if tokens else [_TOKEN])
+    )
+    stack.enter_context(patch("vocab.cli.Dictionary"))
+    stack.enter_context(patch("vocab.cli.enrich_lemma", return_value=enriched_return))
+    stack.enter_context(patch("vocab.cli.assign_single_sense", return_value=assignment_return))
+    stack.enter_context(patch("vocab.cli.needs_disambiguation", return_value=needs_disambig))
+    if no_env:
+        stack.enter_context(patch.dict("os.environ", {}, clear=True))
+
+
+def _mock_anki_builder() -> AsyncMock:
+    """Create a mock AnkiDeckBuilder."""
+    mock_builder = AsyncMock()
+    mock_builder.cards_added = 1
+    mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+    mock_builder.__aexit__ = AsyncMock(return_value=None)
+    return mock_builder
+
+
+class TestBuildCommand:
+    """Tests for the build command."""
+
+    def test_missing_epub_fails(self) -> None:
+        result = runner.invoke(app, ["build", "nonexistent.epub", "-l", "fr"])
+        assert result.exit_code != 0
+
+    def test_help(self) -> None:
+        result = runner.invoke(app, ["build", "--help"])
+        assert result.exit_code == 0
+        assert "--language" in result.output
+        assert "--output" in result.output
+        assert "--no-disambiguation" in result.output
+
+    def test_no_args_shows_help(self) -> None:
+        result = runner.invoke(app, [])
+        assert "Usage" in result.output
+
+    def test_missing_api_key_with_disambiguation(self, tmp_path: Path) -> None:
+        """Should fail early when API key is missing and disambiguation is on."""
+        epub = tmp_path / "test.epub"
+        epub.touch()
+
+        with patch("vocab.cli.load_dotenv"), patch.dict("os.environ", {}, clear=True):
+            result = runner.invoke(app, ["build", str(epub), "-l", "fr"])
+
+        assert result.exit_code == 1
+        assert "ANTHROPIC_API_KEY" in result.output
+
+    def test_no_disambiguation_skips_api_check(self, tmp_path: Path) -> None:
+        """--no-disambiguation should not require API key."""
+        epub = tmp_path / "test.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-disambiguation", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_default_output_path(self, tmp_path: Path) -> None:
+        """Output should default to epub basename with .apkg extension."""
+        epub = tmp_path / "my-book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            mock_cls = stack.enter_context(
+                patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder)
+            )
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-disambiguation", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs["path"] == epub.with_suffix(".apkg")
+
+    def test_custom_output_path(self, tmp_path: Path) -> None:
+        """--output should override the default path."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+        custom_output = tmp_path / "custom.apkg"
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            mock_cls = stack.enter_context(
+                patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder)
+            )
+            result = runner.invoke(
+                app,
+                [
+                    "build",
+                    str(epub),
+                    "-l",
+                    "fr",
+                    "-o",
+                    str(custom_output),
+                    "--no-disambiguation",
+                    "--no-audio",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs["path"] == custom_output
+
+    def test_artifacts_written(self, tmp_path: Path) -> None:
+        """--artifacts should write intermediate files."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+        artifacts_dir = tmp_path / "artifacts"
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                [
+                    "build",
+                    str(epub),
+                    "-l",
+                    "fr",
+                    "--artifacts",
+                    str(artifacts_dir),
+                    "--no-disambiguation",
+                    "--no-audio",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert artifacts_dir.is_dir()
+        assert (artifacts_dir / "01-chapters.jsonl").exists()
+        assert (artifacts_dir / "02-sentences.jsonl").exists()
+        assert (artifacts_dir / "03-tokens.jsonl").exists()
+        assert (artifacts_dir / "04-vocabulary.json").exists()
+        assert (artifacts_dir / "05-enriched.jsonl").exists()
+        assert (artifacts_dir / "06-assigned.jsonl").exists()
+
+    def test_deck_name_default(self, tmp_path: Path) -> None:
+        """Default deck name should be '{Language} Vocabulary'."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            mock_cls = stack.enter_context(
+                patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder)
+            )
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-disambiguation", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs["deck_name"] == "French Vocabulary"
+
+    def test_no_audio_passes_skip_audio_flag(self, tmp_path: Path) -> None:
+        """--no-audio should pass skip_audio=True to AnkiDeckBuilder."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            mock_cls = stack.enter_context(
+                patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder)
+            )
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-disambiguation", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["skip_audio"] is True
+
+    def test_pos_filtering(self, tmp_path: Path) -> None:
+        """--pos should filter lemmas by POS tag."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        verb_token = Token(
+            lemma="dormir",
+            pos="VERB",
+            morph={},
+            original="dort",
+            sentence="Le chat dort.",
+            location=_LOCATION,
+        )
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack, tokens=[_TOKEN, verb_token])
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                [
+                    "build",
+                    str(epub),
+                    "-l",
+                    "fr",
+                    "--pos",
+                    "NOUN",
+                    "--no-disambiguation",
+                    "--no-audio",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_top_filtering(self, tmp_path: Path) -> None:
+        """--top should keep only the N most frequent lemmas after POS filtering."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        loc = _LOCATION
+        # "chat" appears 3 times, "chien" appears 1 time
+        chat = Token(
+            lemma="chat",
+            pos="NOUN",
+            morph={},
+            original="chat",
+            sentence="S1.",
+            location=loc,
+        )
+        chien = Token(
+            lemma="chien",
+            pos="NOUN",
+            morph={},
+            original="chien",
+            sentence="S4.",
+            location=loc,
+        )
+        tokens = [chat, chat, chat, chien]
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack, tokens=tokens)
+            mock_enrich = stack.enter_context(
+                patch("vocab.cli.enrich_lemma", return_value=_make_enriched())
+            )
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                [
+                    "build",
+                    str(epub),
+                    "-l",
+                    "fr",
+                    "--top",
+                    "1",
+                    "--no-disambiguation",
+                    "--no-audio",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # enrich_lemma should only be called once (for "chat", the most frequent)
+        assert mock_enrich.call_count == 1
+
+    def test_enrich_returns_none_rejects_lemma(self, tmp_path: Path) -> None:
+        """When enrich_lemma returns None, the lemma should be skipped."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack)
+            # Override: enrich_lemma returns None
+            stack.enter_context(patch("vocab.cli.enrich_lemma", return_value=None))
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-disambiguation", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Enriched 0 lemmas" in result.output
+
+    def test_disambiguation_success(self, tmp_path: Path) -> None:
+        """Disambiguation should be invoked for ambiguous lemmas."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        assignment = _make_assignment()
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack, needs_disambig=True, no_env=False)
+            stack.enter_context(patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}))
+            mock_disambig = stack.enter_context(
+                patch(
+                    "vocab.cli.disambiguate_senses",
+                    new_callable=AsyncMock,
+                    return_value=[assignment],
+                )
+            )
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_disambig.assert_called_once()
+        assert "1 succeeded" in result.output
+
+    def test_disambiguation_empty_result(self, tmp_path: Path) -> None:
+        """Empty disambiguation result should count as failed."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack, needs_disambig=True, no_env=False)
+            stack.enter_context(patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}))
+            stack.enter_context(
+                patch("vocab.cli.disambiguate_senses", new_callable=AsyncMock, return_value=[])
+            )
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "1 failed" in result.output
+
+    def test_disambiguation_exception(self, tmp_path: Path) -> None:
+        """Disambiguation exception should be caught and counted as failed."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack, needs_disambig=True, no_env=False)
+            stack.enter_context(patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}))
+            stack.enter_context(
+                patch(
+                    "vocab.cli.disambiguate_senses",
+                    new_callable=AsyncMock,
+                    side_effect=RuntimeError("LLM error"),
+                )
+            )
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "1 failed" in result.output
+
+    def test_ambiguous_skipped_with_no_disambiguation(self, tmp_path: Path) -> None:
+        """--no-disambiguation should skip ambiguous lemmas with a message."""
+        epub = tmp_path / "book.epub"
+        epub.touch()
+
+        mock_builder = _mock_anki_builder()
+        with ExitStack() as stack:
+            _enter_pipeline_mocks(stack, needs_disambig=True)
+            stack.enter_context(patch("vocab.cli.AnkiDeckBuilder", return_value=mock_builder))
+            result = runner.invoke(
+                app,
+                ["build", str(epub), "-l", "fr", "--no-disambiguation", "--no-audio"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Skipping disambiguation" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -714,6 +714,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -774,6 +786,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -952,6 +973,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]
@@ -1241,6 +1271,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1273,6 +1316,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1482,6 +1534,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
+]
+
+[[package]]
 name = "typer-slim"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1575,17 +1642,19 @@ dependencies = [
     { name = "httpx" },
     { name = "lxml" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "spacy" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pip" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
-    { name = "python-dotenv" },
     { name = "ruff" },
     { name = "tqdm" },
     { name = "types-tqdm" },
@@ -1601,17 +1670,19 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "spacy", specifier = ">=3.8.11" },
+    { name = "typer", specifier = ">=0.21.1" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pip", specifier = ">=26.0.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "ruff", specifier = ">=0.14.14" },
     { name = "tqdm", specifier = ">=4.67.2" },
     { name = "types-tqdm", specifier = ">=4.67.2.20260202" },


### PR DESCRIPTION
Add a CLI using typer that runs the full epub-to-Anki pipeline as a
single `vocab build` command with configurable parameters.

Key changes:
- VocabularyBuilder class: decouples token accumulation from epub
  iteration, enabling the CLI to hook into each pipeline stage
- ArtifactWriter / NullArtifactWriter: null object pattern for writing
  numbered intermediate artifacts (01-chapters.jsonl through
  07-failed.jsonl) when --artifacts is provided
- CLI with typer: `vocab build book.epub -l fr` runs extraction,
  enrichment, disambiguation, and Anki deck generation
- Options: --language, --output, --deck-name, --artifacts, --top,
  --max-examples, --pos, --model, --no-audio, --no-disambiguation

Dependencies added: typer, python-dotenv (moved from dev).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
